### PR TITLE
Decrease minimal time between IDR frames

### DIFF
--- a/alvr_server/IDRScheduler.h
+++ b/alvr_server/IDRScheduler.h
@@ -15,7 +15,7 @@ public:
 
 	bool CheckIDRInsertion();
 private:
-	static const int MIN_IDR_FRAME_INTERVAL = 2 * 1000 * 1000; // 2-seconds
+	static const int MIN_IDR_FRAME_INTERVAL = 100 * 1000; // 100-milliseconds
 	uint64_t m_insertIDRTime = 0;
 	bool m_scheduled = false;
 	IPCCriticalSection m_IDRCS;


### PR DESCRIPTION
Decrease time between IDR frames during packets loss. 

Might be good to make configurable later. 
Related to #30 