### PR TITLE
Add Presets tab + Boneworks controllers fix

### DIFF
--- a/ALVR/App.config
+++ b/ALVR/App.config
@@ -151,6 +151,24 @@
             <setting name="sharpening" serializeAs="String">
                 <value>0</value>
             </setting>
+            <setting name="leftControllerPositionOffsetX" serializeAs="String">
+                <value>-0.007</value>
+            </setting>
+            <setting name="leftControllerPositionOffsetY" serializeAs="String">
+                <value>0.005</value>
+            </setting>
+            <setting name="leftControllerPositionOffsetZ" serializeAs="String">
+                <value>-0.053</value>
+            </setting>
+            <setting name="leftControllerPitchOffset" serializeAs="String">
+                <value>36</value>
+            </setting>
+            <setting name="leftControllerYawOffset" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="leftControllerRollOffset" serializeAs="String">
+                <value>0</value>
+            </setting>
         </ALVR.Properties.Settings>
     </userSettings>
 </configuration>

--- a/ALVR/Launcher.Designer.cs
+++ b/ALVR/Launcher.Designer.cs
@@ -29,13 +29,13 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle15 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle16 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle17 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle18 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle19 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle20 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle21 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Launcher));
             this.sendClientDebugFlagsButton = new MetroFramework.Controls.MetroButton();
             this.sendDriverTestModeButton = new MetroFramework.Controls.MetroButton();
@@ -73,20 +73,17 @@
             this.flowLayoutPanel39 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel40 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel37 = new MetroFramework.Controls.MetroLabel();
-            this.sharpeningBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel41 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel31 = new MetroFramework.Controls.MetroLabel();
             this.codecHelp = new MetroFramework.Controls.MetroLabel();
             this.codecComboBox = new MetroFramework.Controls.MetroComboBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.forceNV12 = new MetroFramework.Controls.MetroCheckBox();
             this.nv12Tooltip = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel3 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel7 = new MetroFramework.Controls.MetroLabel();
             this.bitrateHelp = new MetroFramework.Controls.MetroLabel();
             this.bitrateLabel = new MetroFramework.Controls.MetroLabel();
-            this.bitrateTrackBar = new MetroFramework.Controls.MetroTrackBar();
             this.flowLayoutPanel5 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel10 = new MetroFramework.Controls.MetroLabel();
             this.resolutionHelp = new MetroFramework.Controls.MetroLabel();
@@ -99,8 +96,6 @@
             this.metroLabel19 = new MetroFramework.Controls.MetroLabel();
             this.bufferLabel = new MetroFramework.Controls.MetroLabel();
             this.bufferHelp = new MetroFramework.Controls.MetroLabel();
-            this.enableColorCorrectionCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.bufferTrackBar = new MetroFramework.Controls.MetroTrackBar();
             this.flowLayoutPanel9 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel21 = new MetroFramework.Controls.MetroLabel();
             this.ffrHelp = new MetroFramework.Controls.MetroLabel();
@@ -109,11 +104,9 @@
             this.ffrMeanLabel = new MetroFramework.Controls.MetroLabel();
             this.ffrStrengthHelp = new MetroFramework.Controls.MetroLabel();
             this.foveationStrengthLabel = new MetroFramework.Controls.MetroLabel();
-            this.foveationStrengthTrackBar = new MetroFramework.Controls.MetroTrackBar();
             this.flowLayoutPanel11 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel23 = new MetroFramework.Controls.MetroLabel();
             this.ffrVerticalOffsetHelp = new MetroFramework.Controls.MetroLabel();
-            this.foveationVerticalOffsetTrackBar = new MetroFramework.Controls.MetroTrackBar();
             this.foveationVerticalOffsetLabel = new MetroFramework.Controls.MetroLabel();
             this.panel1 = new System.Windows.Forms.Panel();
             this.metroLabel34 = new MetroFramework.Controls.MetroLabel();
@@ -129,70 +122,63 @@
             this.flowLayoutPanel32 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel28 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel33 = new MetroFramework.Controls.MetroLabel();
-            this.saturationBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel30 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel25 = new MetroFramework.Controls.MetroLabel();
-            this.contrastBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel33 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel29 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel32 = new MetroFramework.Controls.MetroLabel();
-            this.brightnessBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel31 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel24 = new MetroFramework.Controls.MetroLabel();
-            this.gammaBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel34 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel35 = new MetroFramework.Controls.MetroLabel();
             this.bufferOffsetLabel = new MetroFramework.Controls.MetroLabel();
             this.soundTab = new MetroFramework.Controls.MetroTabPage();
             this.tableLayoutPanel9 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel13 = new System.Windows.Forms.FlowLayoutPanel();
-            this.soundCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.noSoundDeviceLabel = new MetroFramework.Controls.MetroLabel();
             this.soundDeviceComboBox = new MetroFramework.Controls.MetroComboBox();
-            this.streamMic = new MetroFramework.Controls.MetroCheckBox();
             this.flowLayoutPanel14 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel20 = new MetroFramework.Controls.MetroLabel();
             this.metroLink1 = new MetroFramework.Controls.MetroLink();
-            this.defaultSoundDeviceCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.otherTab = new MetroFramework.Controls.MetroTabPage();
             this.tableLayoutPanel11 = new System.Windows.Forms.TableLayoutPanel();
-            this.flowLayoutPanel16 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel12 = new MetroFramework.Controls.MetroLabel();
-            this.controllerPoseOffset = new MetroFramework.Controls.MetroTextBox();
-            this.metroButton1 = new MetroFramework.Controls.MetroButton();
             this.flowLayoutPanel26 = new System.Windows.Forms.FlowLayoutPanel();
-            this.onlySteamVRCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.flowLayoutPanel35 = new System.Windows.Forms.FlowLayoutPanel();
-            this.steamAutoLaunch = new MetroFramework.Controls.MetroCheckBox();
             this.autoLaunchHelp = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel36 = new System.Windows.Forms.FlowLayoutPanel();
-            this.launchMinimized = new MetroFramework.Controls.MetroCheckBox();
-            this.force60HzCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.suppressFrameDropCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.disableThrottlingCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.disableController = new MetroFramework.Controls.MetroCheckBox();
-            this.force3DOFCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.flowLayoutPanel15 = new System.Windows.Forms.FlowLayoutPanel();
-            this.aggressiveKeyframeResend = new MetroFramework.Controls.MetroCheckBox();
             this.aggressiveKeyframeResendHelp = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel17 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel29 = new MetroFramework.Controls.MetroLabel();
-            this.trackingFrameOffsetTextBox = new MetroFramework.Controls.MetroTextBox();
             this.saveTrackingFrameOffsetButton = new MetroFramework.Controls.MetroButton();
             this.metroLabel30 = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel24 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel27 = new MetroFramework.Controls.MetroLabel();
-            this.connectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
             this.refConnectCommandButton = new MetroFramework.Controls.MetroButton();
             this.metroLabel26 = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel25 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel28 = new MetroFramework.Controls.MetroLabel();
-            this.disconnectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
             this.refDisconnectCommandButton = new MetroFramework.Controls.MetroButton();
+            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel43 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel40 = new MetroFramework.Controls.MetroLabel();
+            this.controllerRotationOffsetHelp = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel37 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel39 = new MetroFramework.Controls.MetroLabel();
+            this.controllerPositionOffsetHelp = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel38 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel36 = new MetroFramework.Controls.MetroLabel();
+            this.handTrackingModeHelp = new MetroFramework.Controls.MetroLabel();
             this.controllerModeComboBox = new MetroFramework.Controls.MetroComboBox();
+            this.flowLayoutPanel16 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel12 = new MetroFramework.Controls.MetroLabel();
+            this.metroButton1 = new MetroFramework.Controls.MetroButton();
+            this.metroLabel41 = new MetroFramework.Controls.MetroLabel();
+            this.presetsTab = new MetroFramework.Controls.MetroTabPage();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.metroLabel38 = new MetroFramework.Controls.MetroLabel();
+            this.flowLayoutPanel42 = new System.Windows.Forms.FlowLayoutPanel();
+            this.revertToDefaultButton = new MetroFramework.Controls.MetroButton();
             this.debugTab = new MetroFramework.Controls.MetroTabPage();
             this.tableLayoutPanel14 = new System.Windows.Forms.TableLayoutPanel();
             this.metroLabel5 = new MetroFramework.Controls.MetroLabel();
@@ -207,9 +193,7 @@
             this.captureLayerDDSButton = new MetroFramework.Controls.MetroButton();
             this.packetlossButton = new MetroFramework.Controls.MetroButton();
             this.flowLayoutPanel21 = new System.Windows.Forms.FlowLayoutPanel();
-            this.debugLogCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.metroCheckBox1 = new MetroFramework.Controls.MetroCheckBox();
-            this.debugCaptureOutputCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.metroCheckBox2 = new MetroFramework.Controls.MetroCheckBox();
             this.metroCheckBox3 = new MetroFramework.Controls.MetroCheckBox();
             this.metroButton5 = new MetroFramework.Controls.MetroButton();
@@ -234,11 +218,41 @@
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
             this.notifyIcon1 = new System.Windows.Forms.NotifyIcon(this.components);
-            this.presetsTab = new MetroFramework.Controls.MetroTabPage();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.revertToDefaultButton = new MetroFramework.Controls.MetroButton();
-            this.flowLayoutPanel42 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel38 = new MetroFramework.Controls.MetroLabel();
+            this.sharpeningBox = new System.Windows.Forms.NumericUpDown();
+            this.forceNV12 = new MetroFramework.Controls.MetroCheckBox();
+            this.bitrateTrackBar = new MetroFramework.Controls.MetroTrackBar();
+            this.enableColorCorrectionCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.bufferTrackBar = new MetroFramework.Controls.MetroTrackBar();
+            this.foveationStrengthTrackBar = new MetroFramework.Controls.MetroTrackBar();
+            this.foveationVerticalOffsetTrackBar = new MetroFramework.Controls.MetroTrackBar();
+            this.saturationBox = new System.Windows.Forms.NumericUpDown();
+            this.contrastBox = new System.Windows.Forms.NumericUpDown();
+            this.brightnessBox = new System.Windows.Forms.NumericUpDown();
+            this.gammaBox = new System.Windows.Forms.NumericUpDown();
+            this.soundCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.streamMic = new MetroFramework.Controls.MetroCheckBox();
+            this.defaultSoundDeviceCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.onlySteamVRCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.steamAutoLaunch = new MetroFramework.Controls.MetroCheckBox();
+            this.launchMinimized = new MetroFramework.Controls.MetroCheckBox();
+            this.force60HzCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.suppressFrameDropCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.disableThrottlingCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.disableController = new MetroFramework.Controls.MetroCheckBox();
+            this.force3DOFCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.aggressiveKeyframeResend = new MetroFramework.Controls.MetroCheckBox();
+            this.trackingFrameOffsetTextBox = new MetroFramework.Controls.MetroTextBox();
+            this.connectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
+            this.disconnectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
+            this.numericUpDown4 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown5 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown6 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown2 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown3 = new System.Windows.Forms.NumericUpDown();
+            this.controllerPoseOffset = new MetroFramework.Controls.MetroTextBox();
+            this.debugLogCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.debugCaptureOutputCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.metroTabControl1.SuspendLayout();
             this.serverTab.SuspendLayout();
             this.findingPanel.SuspendLayout();
@@ -255,7 +269,6 @@
             this.tableLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel39.SuspendLayout();
             this.flowLayoutPanel40.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.sharpeningBox)).BeginInit();
             this.flowLayoutPanel2.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel3.SuspendLayout();
@@ -270,14 +283,10 @@
             this.flowLayoutPanel27.SuspendLayout();
             this.flowLayoutPanel32.SuspendLayout();
             this.flowLayoutPanel28.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.saturationBox)).BeginInit();
             this.flowLayoutPanel30.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.contrastBox)).BeginInit();
             this.flowLayoutPanel33.SuspendLayout();
             this.flowLayoutPanel29.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.brightnessBox)).BeginInit();
             this.flowLayoutPanel31.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.gammaBox)).BeginInit();
             this.flowLayoutPanel34.SuspendLayout();
             this.soundTab.SuspendLayout();
             this.tableLayoutPanel9.SuspendLayout();
@@ -285,7 +294,6 @@
             this.flowLayoutPanel14.SuspendLayout();
             this.otherTab.SuspendLayout();
             this.tableLayoutPanel11.SuspendLayout();
-            this.flowLayoutPanel16.SuspendLayout();
             this.flowLayoutPanel26.SuspendLayout();
             this.flowLayoutPanel35.SuspendLayout();
             this.flowLayoutPanel36.SuspendLayout();
@@ -293,8 +301,14 @@
             this.flowLayoutPanel17.SuspendLayout();
             this.flowLayoutPanel24.SuspendLayout();
             this.flowLayoutPanel25.SuspendLayout();
+            this.tableLayoutPanel3.SuspendLayout();
+            this.flowLayoutPanel43.SuspendLayout();
             this.flowLayoutPanel37.SuspendLayout();
             this.flowLayoutPanel38.SuspendLayout();
+            this.flowLayoutPanel16.SuspendLayout();
+            this.presetsTab.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            this.flowLayoutPanel42.SuspendLayout();
             this.debugTab.SuspendLayout();
             this.tableLayoutPanel14.SuspendLayout();
             this.flowLayoutPanel18.SuspendLayout();
@@ -307,9 +321,17 @@
             this.flowLayoutPanel23.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.resolutionBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            this.presetsTab.SuspendLayout();
-            this.tableLayoutPanel2.SuspendLayout();
-            this.flowLayoutPanel42.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.sharpeningBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.saturationBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.contrastBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.brightnessBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.gammaBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown4)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown5)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown6)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).BeginInit();
             this.SuspendLayout();
             // 
             // sendClientDebugFlagsButton
@@ -360,7 +382,7 @@
             this.metroTabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.metroTabControl1.Location = new System.Drawing.Point(20, 65);
             this.metroTabControl1.Name = "metroTabControl1";
-            this.metroTabControl1.SelectedIndex = 4;
+            this.metroTabControl1.SelectedIndex = 3;
             this.metroTabControl1.Size = new System.Drawing.Size(663, 456);
             this.metroTabControl1.TabIndex = 8;
             // 
@@ -426,14 +448,14 @@
             this.dataGridView1.AllowUserToResizeRows = false;
             this.dataGridView1.BackgroundColor = System.Drawing.Color.White;
             this.dataGridView1.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
-            dataGridViewCellStyle15.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle15.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle15.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            dataGridViewCellStyle15.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle15.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle15.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle15.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridView1.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle15;
+            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataGridView1.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView1.ColumnHeadersVisible = false;
             this.dataGridView1.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
@@ -442,32 +464,32 @@
             this.refreshRateColumn,
             this.Button});
             this.tableLayoutPanel7.SetColumnSpan(this.dataGridView1, 3);
-            dataGridViewCellStyle16.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle16.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle16.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            dataGridViewCellStyle16.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle16.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle16.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle16.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dataGridView1.DefaultCellStyle = dataGridViewCellStyle16;
+            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.dataGridView1.DefaultCellStyle = dataGridViewCellStyle2;
             this.dataGridView1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dataGridView1.Location = new System.Drawing.Point(3, 108);
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.ReadOnly = true;
-            dataGridViewCellStyle17.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle17.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle17.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            dataGridViewCellStyle17.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle17.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle17.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle17.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridView1.RowHeadersDefaultCellStyle = dataGridViewCellStyle17;
+            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle3.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataGridView1.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
             this.dataGridView1.RowHeadersVisible = false;
             this.dataGridView1.RowHeadersWidth = 51;
-            dataGridViewCellStyle18.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle18.SelectionBackColor = System.Drawing.Color.White;
-            dataGridViewCellStyle18.SelectionForeColor = System.Drawing.Color.Black;
-            this.dataGridView1.RowsDefaultCellStyle = dataGridViewCellStyle18;
+            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.Color.White;
+            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.Color.Black;
+            this.dataGridView1.RowsDefaultCellStyle = dataGridViewCellStyle4;
             this.dataGridView1.RowTemplate.DefaultCellStyle.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(192)))), ((int)(((byte)(192)))));
             this.dataGridView1.RowTemplate.Height = 40;
             this.dataGridView1.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
@@ -678,39 +700,39 @@
             this.statDataGridView.AllowUserToDeleteRows = false;
             this.statDataGridView.BackgroundColor = System.Drawing.Color.White;
             this.statDataGridView.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
-            dataGridViewCellStyle19.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle19.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle19.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            dataGridViewCellStyle19.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle19.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle19.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle19.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.statDataGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle19;
+            dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle5.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            dataGridViewCellStyle5.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.statDataGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle5;
             this.statDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.statDataGridView.ColumnHeadersVisible = false;
             this.statDataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Name1,
             this.Value1});
-            dataGridViewCellStyle20.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle20.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle20.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            dataGridViewCellStyle20.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle20.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle20.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle20.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.statDataGridView.DefaultCellStyle = dataGridViewCellStyle20;
+            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle6.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            dataGridViewCellStyle6.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle6.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle6.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.statDataGridView.DefaultCellStyle = dataGridViewCellStyle6;
             this.statDataGridView.Dock = System.Windows.Forms.DockStyle.Fill;
             this.statDataGridView.Location = new System.Drawing.Point(308, 13);
             this.statDataGridView.Name = "statDataGridView";
             this.statDataGridView.ReadOnly = true;
-            dataGridViewCellStyle21.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle21.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle21.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            dataGridViewCellStyle21.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle21.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle21.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle21.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.statDataGridView.RowHeadersDefaultCellStyle = dataGridViewCellStyle21;
+            dataGridViewCellStyle7.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle7.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle7.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            dataGridViewCellStyle7.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle7.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle7.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle7.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.statDataGridView.RowHeadersDefaultCellStyle = dataGridViewCellStyle7;
             this.statDataGridView.RowHeadersVisible = false;
             this.statDataGridView.RowHeadersWidth = 51;
             this.tableLayoutPanel8.SetRowSpan(this.statDataGridView, 3);
@@ -890,31 +912,6 @@
             this.metroLabel37.TabIndex = 45;
             this.metroLabel37.Text = "Sharpening";
             // 
-            // sharpeningBox
-            // 
-            this.sharpeningBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "sharpening", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.sharpeningBox.DecimalPlaces = 2;
-            this.sharpeningBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.sharpeningBox.Location = new System.Drawing.Point(82, 3);
-            this.sharpeningBox.Maximum = new decimal(new int[] {
-            500,
-            0,
-            0,
-            131072});
-            this.sharpeningBox.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.sharpeningBox.Name = "sharpeningBox";
-            this.sharpeningBox.Size = new System.Drawing.Size(44, 20);
-            this.sharpeningBox.TabIndex = 44;
-            this.sharpeningBox.Value = global::ALVR.Properties.Settings.Default.sharpening;
-            // 
             // flowLayoutPanel41
             // 
             this.flowLayoutPanel41.Location = new System.Drawing.Point(128, 0);
@@ -980,20 +977,6 @@
             this.flowLayoutPanel1.Size = new System.Drawing.Size(136, 21);
             this.flowLayoutPanel1.TabIndex = 38;
             // 
-            // forceNV12
-            // 
-            this.forceNV12.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.forceNV12.AutoSize = true;
-            this.forceNV12.Checked = global::ALVR.Properties.Settings.Default.nv12;
-            this.forceNV12.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "nv12", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.forceNV12.Location = new System.Drawing.Point(3, 3);
-            this.forceNV12.Margin = new System.Windows.Forms.Padding(3, 3, 0, 3);
-            this.forceNV12.Name = "forceNV12";
-            this.forceNV12.Size = new System.Drawing.Size(115, 15);
-            this.forceNV12.TabIndex = 35;
-            this.forceNV12.Text = "use custom NV12";
-            this.forceNV12.UseVisualStyleBackColor = true;
-            // 
             // nv12Tooltip
             // 
             this.nv12Tooltip.AutoSize = true;
@@ -1049,22 +1032,6 @@
             this.bitrateLabel.Size = new System.Drawing.Size(60, 19);
             this.bitrateLabel.TabIndex = 5;
             this.bitrateLabel.Text = "30Mbps";
-            // 
-            // bitrateTrackBar
-            // 
-            this.bitrateTrackBar.BackColor = System.Drawing.Color.Transparent;
-            this.bitrateTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "bitrate", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.bitrateTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.bitrateTrackBar.Location = new System.Drawing.Point(233, 73);
-            this.bitrateTrackBar.Maximum = 250;
-            this.bitrateTrackBar.Minimum = 1;
-            this.bitrateTrackBar.Name = "bitrateTrackBar";
-            this.bitrateTrackBar.Size = new System.Drawing.Size(269, 25);
-            this.bitrateTrackBar.TabIndex = 2;
-            this.bitrateTrackBar.Text = "metroTrackBar1";
-            this.bitrateTrackBar.Value = global::ALVR.Properties.Settings.Default.bitrate;
-            this.bitrateTrackBar.ValueChanged += new System.EventHandler(this.bitrateTrackBar_ValueChanged);
-            this.bitrateTrackBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.bitrateTrackBar_Scroll);
             // 
             // flowLayoutPanel5
             // 
@@ -1213,33 +1180,6 @@
             this.bufferHelp.Text = "?";
             this.bufferHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
-            // enableColorCorrectionCheckBox
-            // 
-            this.enableColorCorrectionCheckBox.AutoSize = true;
-            this.enableColorCorrectionCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableColorCorrection;
-            this.enableColorCorrectionCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableColorCorrection", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.enableColorCorrectionCheckBox.Location = new System.Drawing.Point(233, 295);
-            this.enableColorCorrectionCheckBox.Name = "enableColorCorrectionCheckBox";
-            this.enableColorCorrectionCheckBox.Size = new System.Drawing.Size(58, 15);
-            this.enableColorCorrectionCheckBox.TabIndex = 40;
-            this.enableColorCorrectionCheckBox.Text = "Enable";
-            this.enableColorCorrectionCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // bufferTrackBar
-            // 
-            this.bufferTrackBar.BackColor = System.Drawing.Color.Transparent;
-            this.bufferTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "bufferOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.bufferTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.bufferTrackBar.Location = new System.Drawing.Point(233, 160);
-            this.bufferTrackBar.Minimum = -100;
-            this.bufferTrackBar.Name = "bufferTrackBar";
-            this.bufferTrackBar.Size = new System.Drawing.Size(269, 20);
-            this.bufferTrackBar.TabIndex = 2;
-            this.bufferTrackBar.Text = "metroTrackBar1";
-            this.bufferTrackBar.Value = global::ALVR.Properties.Settings.Default.bufferOffset;
-            this.bufferTrackBar.ValueChanged += new System.EventHandler(this.bufferTrackBar_ValueChanged);
-            this.bufferTrackBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.bufferTrackBar_Scroll);
-            // 
             // flowLayoutPanel9
             // 
             this.flowLayoutPanel9.Anchor = System.Windows.Forms.AnchorStyles.Right;
@@ -1338,23 +1278,6 @@
             this.foveationStrengthLabel.Text = "2";
             this.foveationStrengthLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // foveationStrengthTrackBar
-            // 
-            this.foveationStrengthTrackBar.BackColor = System.Drawing.Color.Transparent;
-            this.foveationStrengthTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "foveationStrength", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.foveationStrengthTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.foveationStrengthTrackBar.LargeChange = 100;
-            this.foveationStrengthTrackBar.Location = new System.Drawing.Point(233, 240);
-            this.foveationStrengthTrackBar.Maximum = 500;
-            this.foveationStrengthTrackBar.MaximumSize = new System.Drawing.Size(0, 14);
-            this.foveationStrengthTrackBar.Name = "foveationStrengthTrackBar";
-            this.foveationStrengthTrackBar.Size = new System.Drawing.Size(269, 10);
-            this.foveationStrengthTrackBar.SmallChange = 10;
-            this.foveationStrengthTrackBar.TabIndex = 30;
-            this.foveationStrengthTrackBar.Text = "metroTrackBar1";
-            this.foveationStrengthTrackBar.Value = global::ALVR.Properties.Settings.Default.foveationStrength;
-            this.foveationStrengthTrackBar.ValueChanged += new System.EventHandler(this.FoveationStrengthTrackBar_ValueChanged);
-            // 
             // flowLayoutPanel11
             // 
             this.flowLayoutPanel11.AutoSize = true;
@@ -1388,23 +1311,6 @@
             this.ffrVerticalOffsetHelp.TabIndex = 32;
             this.ffrVerticalOffsetHelp.Text = "?";
             this.ffrVerticalOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // foveationVerticalOffsetTrackBar
-            // 
-            this.foveationVerticalOffsetTrackBar.BackColor = System.Drawing.Color.Transparent;
-            this.foveationVerticalOffsetTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "foveationVerticalOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.foveationVerticalOffsetTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.foveationVerticalOffsetTrackBar.LargeChange = 2;
-            this.foveationVerticalOffsetTrackBar.Location = new System.Drawing.Point(233, 275);
-            this.foveationVerticalOffsetTrackBar.Maximum = 10;
-            this.foveationVerticalOffsetTrackBar.Minimum = -10;
-            this.foveationVerticalOffsetTrackBar.MouseWheelBarPartitions = 1;
-            this.foveationVerticalOffsetTrackBar.Name = "foveationVerticalOffsetTrackBar";
-            this.foveationVerticalOffsetTrackBar.Size = new System.Drawing.Size(269, 14);
-            this.foveationVerticalOffsetTrackBar.TabIndex = 34;
-            this.foveationVerticalOffsetTrackBar.Text = "metroTrackBar1";
-            this.foveationVerticalOffsetTrackBar.Value = global::ALVR.Properties.Settings.Default.foveationVerticalOffset;
-            this.foveationVerticalOffsetTrackBar.ValueChanged += new System.EventHandler(this.FoveationVerticalOffsetTrackBar_ValueChanged);
             // 
             // foveationVerticalOffsetLabel
             // 
@@ -1571,31 +1477,6 @@
             this.metroLabel33.TabIndex = 47;
             this.metroLabel33.Text = "Saturation";
             // 
-            // saturationBox
-            // 
-            this.saturationBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "saturation", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.saturationBox.DecimalPlaces = 2;
-            this.saturationBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.saturationBox.Location = new System.Drawing.Point(75, 3);
-            this.saturationBox.Maximum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.saturationBox.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            -2147483648});
-            this.saturationBox.Name = "saturationBox";
-            this.saturationBox.Size = new System.Drawing.Size(46, 20);
-            this.saturationBox.TabIndex = 48;
-            this.saturationBox.Value = global::ALVR.Properties.Settings.Default.saturation;
-            // 
             // flowLayoutPanel30
             // 
             this.flowLayoutPanel30.Controls.Add(this.metroLabel25);
@@ -1616,31 +1497,6 @@
             this.metroLabel25.Size = new System.Drawing.Size(58, 19);
             this.metroLabel25.TabIndex = 43;
             this.metroLabel25.Text = "Contrast";
-            // 
-            // contrastBox
-            // 
-            this.contrastBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "contrast", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.contrastBox.DecimalPlaces = 2;
-            this.contrastBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.contrastBox.Location = new System.Drawing.Point(65, 3);
-            this.contrastBox.Maximum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            131072});
-            this.contrastBox.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.contrastBox.Name = "contrastBox";
-            this.contrastBox.Size = new System.Drawing.Size(45, 20);
-            this.contrastBox.TabIndex = 46;
-            this.contrastBox.Value = global::ALVR.Properties.Settings.Default.contrast;
             // 
             // flowLayoutPanel33
             // 
@@ -1677,31 +1533,6 @@
             this.metroLabel32.TabIndex = 45;
             this.metroLabel32.Text = "Brightness";
             // 
-            // brightnessBox
-            // 
-            this.brightnessBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "brightness", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.brightnessBox.DecimalPlaces = 2;
-            this.brightnessBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.brightnessBox.Location = new System.Drawing.Point(75, 3);
-            this.brightnessBox.Maximum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            131072});
-            this.brightnessBox.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.brightnessBox.Name = "brightnessBox";
-            this.brightnessBox.Size = new System.Drawing.Size(44, 20);
-            this.brightnessBox.TabIndex = 44;
-            this.brightnessBox.Value = global::ALVR.Properties.Settings.Default.brightness;
-            // 
             // flowLayoutPanel31
             // 
             this.flowLayoutPanel31.Controls.Add(this.metroLabel24);
@@ -1722,26 +1553,6 @@
             this.metroLabel24.Size = new System.Drawing.Size(56, 19);
             this.metroLabel24.TabIndex = 41;
             this.metroLabel24.Text = "Gamma";
-            // 
-            // gammaBox
-            // 
-            this.gammaBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "gamma", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.gammaBox.DecimalPlaces = 2;
-            this.gammaBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.gammaBox.Location = new System.Drawing.Point(63, 3);
-            this.gammaBox.Maximum = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
-            this.gammaBox.Name = "gammaBox";
-            this.gammaBox.Size = new System.Drawing.Size(45, 20);
-            this.gammaBox.TabIndex = 42;
-            this.gammaBox.Value = global::ALVR.Properties.Settings.Default.gamma;
             // 
             // flowLayoutPanel34
             // 
@@ -1822,20 +1633,6 @@
             this.flowLayoutPanel13.TabIndex = 0;
             this.flowLayoutPanel13.WrapContents = false;
             // 
-            // soundCheckBox
-            // 
-            this.soundCheckBox.AutoSize = true;
-            this.soundCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableSound;
-            this.soundCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.soundCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableSound", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.soundCheckBox.Location = new System.Drawing.Point(3, 3);
-            this.soundCheckBox.Name = "soundCheckBox";
-            this.soundCheckBox.Size = new System.Drawing.Size(92, 15);
-            this.soundCheckBox.TabIndex = 2;
-            this.soundCheckBox.Text = "Steam sound";
-            this.soundCheckBox.UseVisualStyleBackColor = true;
-            this.soundCheckBox.CheckedChanged += new System.EventHandler(this.soundCheckBox_CheckedChanged);
-            // 
             // noSoundDeviceLabel
             // 
             this.noSoundDeviceLabel.AutoSize = true;
@@ -1855,20 +1652,6 @@
             this.soundDeviceComboBox.Name = "soundDeviceComboBox";
             this.soundDeviceComboBox.Size = new System.Drawing.Size(469, 29);
             this.soundDeviceComboBox.TabIndex = 3;
-            // 
-            // streamMic
-            // 
-            this.streamMic.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.streamMic.AutoSize = true;
-            this.streamMic.Checked = global::ALVR.Properties.Settings.Default.streamMic;
-            this.streamMic.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "streamMic", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.streamMic.Location = new System.Drawing.Point(3, 73);
-            this.streamMic.Name = "streamMic";
-            this.streamMic.Size = new System.Drawing.Size(162, 15);
-            this.streamMic.TabIndex = 5;
-            this.streamMic.Text = "Stream Quest Microphone";
-            this.streamMic.UseVisualStyleBackColor = true;
-            this.streamMic.CheckedChanged += new System.EventHandler(this.metroCheckBox4_CheckedChanged);
             // 
             // flowLayoutPanel14
             // 
@@ -1904,22 +1687,6 @@
             this.metroLink1.Text = " https://www.vb-audio.com/Cable/";
             this.metroLink1.Click += new System.EventHandler(this.metroLink1_Click);
             // 
-            // defaultSoundDeviceCheckBox
-            // 
-            this.defaultSoundDeviceCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.defaultSoundDeviceCheckBox.AutoSize = true;
-            this.defaultSoundDeviceCheckBox.Checked = global::ALVR.Properties.Settings.Default.useDefaultSoundDevice;
-            this.defaultSoundDeviceCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.defaultSoundDeviceCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "useDefaultSoundDevice", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.defaultSoundDeviceCheckBox.Location = new System.Drawing.Point(20, 41);
-            this.defaultSoundDeviceCheckBox.Margin = new System.Windows.Forms.Padding(20, 3, 3, 3);
-            this.defaultSoundDeviceCheckBox.Name = "defaultSoundDeviceCheckBox";
-            this.defaultSoundDeviceCheckBox.Size = new System.Drawing.Size(119, 15);
-            this.defaultSoundDeviceCheckBox.TabIndex = 2;
-            this.defaultSoundDeviceCheckBox.Text = "Use default device";
-            this.defaultSoundDeviceCheckBox.UseVisualStyleBackColor = true;
-            this.defaultSoundDeviceCheckBox.CheckedChanged += new System.EventHandler(this.defaultSoundDeviceCheckBox_CheckedChanged);
-            // 
             // otherTab
             // 
             this.otherTab.Controls.Add(this.tableLayoutPanel11);
@@ -1938,22 +1705,19 @@
             // 
             this.tableLayoutPanel11.BackColor = System.Drawing.SystemColors.Window;
             this.tableLayoutPanel11.ColumnCount = 2;
-            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel16, 0, 0);
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel26, 1, 1);
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel17, 0, 7);
-            this.tableLayoutPanel11.Controls.Add(this.metroLabel30, 1, 7);
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel24, 0, 5);
-            this.tableLayoutPanel11.Controls.Add(this.metroLabel26, 0, 4);
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel25, 0, 6);
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel37, 0, 1);
+            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel26, 1, 0);
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel17, 0, 6);
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel24, 0, 4);
+            this.tableLayoutPanel11.Controls.Add(this.metroLabel26, 0, 3);
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel25, 0, 5);
+            this.tableLayoutPanel11.Controls.Add(this.tableLayoutPanel3, 0, 0);
             this.tableLayoutPanel11.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel11.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel11.Name = "tableLayoutPanel11";
             this.tableLayoutPanel11.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
-            this.tableLayoutPanel11.RowCount = 8;
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.RowCount = 7;
             this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -1965,52 +1729,9 @@
             this.tableLayoutPanel11.TabIndex = 37;
             this.tableLayoutPanel11.Paint += new System.Windows.Forms.PaintEventHandler(this.tableLayoutPanel11_Paint);
             // 
-            // flowLayoutPanel16
-            // 
-            this.flowLayoutPanel16.AutoSize = true;
-            this.flowLayoutPanel16.Controls.Add(this.metroLabel12);
-            this.flowLayoutPanel16.Controls.Add(this.controllerPoseOffset);
-            this.flowLayoutPanel16.Controls.Add(this.metroButton1);
-            this.flowLayoutPanel16.Location = new System.Drawing.Point(3, 13);
-            this.flowLayoutPanel16.Name = "flowLayoutPanel16";
-            this.flowLayoutPanel16.Size = new System.Drawing.Size(283, 31);
-            this.flowLayoutPanel16.TabIndex = 37;
-            this.flowLayoutPanel16.WrapContents = false;
-            // 
-            // metroLabel12
-            // 
-            this.metroLabel12.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel12.AutoSize = true;
-            this.metroLabel12.Location = new System.Drawing.Point(3, 6);
-            this.metroLabel12.Name = "metroLabel12";
-            this.metroLabel12.Size = new System.Drawing.Size(138, 19);
-            this.metroLabel12.TabIndex = 20;
-            this.metroLabel12.Text = "Controller Pose Offset";
-            this.metroLabel12.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // controllerPoseOffset
-            // 
-            this.controllerPoseOffset.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.controllerPoseOffset.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "controllerPoseOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.controllerPoseOffset.Location = new System.Drawing.Point(147, 6);
-            this.controllerPoseOffset.Name = "controllerPoseOffset";
-            this.controllerPoseOffset.Size = new System.Drawing.Size(52, 19);
-            this.controllerPoseOffset.TabIndex = 21;
-            this.controllerPoseOffset.Text = global::ALVR.Properties.Settings.Default.controllerPoseOffset;
-            this.controllerPoseOffset.Click += new System.EventHandler(this.controllerPoseOffset_Click);
-            // 
-            // metroButton1
-            // 
-            this.metroButton1.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroButton1.Location = new System.Drawing.Point(205, 3);
-            this.metroButton1.Name = "metroButton1";
-            this.metroButton1.Size = new System.Drawing.Size(75, 25);
-            this.metroButton1.TabIndex = 22;
-            this.metroButton1.Text = "Save";
-            this.metroButton1.Click += new System.EventHandler(this.metroButton1_Click);
-            // 
             // flowLayoutPanel26
             // 
+            this.flowLayoutPanel26.AutoSize = true;
             this.flowLayoutPanel26.Controls.Add(this.onlySteamVRCheckBox);
             this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel35);
             this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel36);
@@ -2022,53 +1743,27 @@
             this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel15);
             this.flowLayoutPanel26.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel26.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanel26.Location = new System.Drawing.Point(467, 50);
+            this.flowLayoutPanel26.Location = new System.Drawing.Point(414, 13);
             this.flowLayoutPanel26.Name = "flowLayoutPanel26";
-            this.flowLayoutPanel26.Padding = new System.Windows.Forms.Padding(50, 0, 0, 0);
-            this.flowLayoutPanel26.Size = new System.Drawing.Size(185, 245);
+            this.flowLayoutPanel26.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
+            this.flowLayoutPanel26.Size = new System.Drawing.Size(238, 276);
             this.flowLayoutPanel26.TabIndex = 40;
             this.flowLayoutPanel26.WrapContents = false;
             // 
-            // onlySteamVRCheckBox
-            // 
-            this.onlySteamVRCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.onlySteamVRCheckBox.AutoSize = true;
-            this.onlySteamVRCheckBox.Checked = global::ALVR.Properties.Settings.Default.onlySteamVR;
-            this.onlySteamVRCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "onlySteamVR", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.onlySteamVRCheckBox.Location = new System.Drawing.Point(53, 3);
-            this.onlySteamVRCheckBox.Name = "onlySteamVRCheckBox";
-            this.onlySteamVRCheckBox.Size = new System.Drawing.Size(221, 15);
-            this.onlySteamVRCheckBox.TabIndex = 29;
-            this.onlySteamVRCheckBox.Text = "Launch only SteamVR without Steam.";
-            this.onlySteamVRCheckBox.UseVisualStyleBackColor = true;
-            // 
             // flowLayoutPanel35
             // 
-            this.flowLayoutPanel35.AutoSize = true;
             this.flowLayoutPanel35.Controls.Add(this.steamAutoLaunch);
             this.flowLayoutPanel35.Controls.Add(this.autoLaunchHelp);
-            this.flowLayoutPanel35.Location = new System.Drawing.Point(50, 21);
+            this.flowLayoutPanel35.Location = new System.Drawing.Point(5, 21);
             this.flowLayoutPanel35.Margin = new System.Windows.Forms.Padding(0);
             this.flowLayoutPanel35.Name = "flowLayoutPanel35";
-            this.flowLayoutPanel35.Size = new System.Drawing.Size(212, 40);
+            this.flowLayoutPanel35.Size = new System.Drawing.Size(233, 21);
             this.flowLayoutPanel35.TabIndex = 37;
-            // 
-            // steamAutoLaunch
-            // 
-            this.steamAutoLaunch.AutoSize = true;
-            this.steamAutoLaunch.Checked = global::ALVR.Properties.Settings.Default.steamAutolaunch;
-            this.steamAutoLaunch.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "steamAutolaunch", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.steamAutoLaunch.Location = new System.Drawing.Point(3, 3);
-            this.steamAutoLaunch.Name = "steamAutoLaunch";
-            this.steamAutoLaunch.Size = new System.Drawing.Size(206, 15);
-            this.steamAutoLaunch.TabIndex = 36;
-            this.steamAutoLaunch.Text = "Launch SteamVR on HMD connect";
-            this.steamAutoLaunch.UseVisualStyleBackColor = true;
             // 
             // autoLaunchHelp
             // 
             this.autoLaunchHelp.AutoSize = true;
-            this.autoLaunchHelp.Location = new System.Drawing.Point(3, 21);
+            this.autoLaunchHelp.Location = new System.Drawing.Point(215, 0);
             this.autoLaunchHelp.Name = "autoLaunchHelp";
             this.autoLaunchHelp.Size = new System.Drawing.Size(15, 19);
             this.autoLaunchHelp.TabIndex = 37;
@@ -2079,113 +1774,22 @@
             // 
             this.flowLayoutPanel36.AutoSize = true;
             this.flowLayoutPanel36.Controls.Add(this.launchMinimized);
-            this.flowLayoutPanel36.Location = new System.Drawing.Point(50, 61);
+            this.flowLayoutPanel36.Location = new System.Drawing.Point(5, 42);
             this.flowLayoutPanel36.Margin = new System.Windows.Forms.Padding(0);
             this.flowLayoutPanel36.Name = "flowLayoutPanel36";
             this.flowLayoutPanel36.Size = new System.Drawing.Size(157, 21);
             this.flowLayoutPanel36.TabIndex = 38;
-            // 
-            // launchMinimized
-            // 
-            this.launchMinimized.AutoSize = true;
-            this.launchMinimized.Checked = global::ALVR.Properties.Settings.Default.launchMinimized;
-            this.launchMinimized.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "launchMinimized", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.launchMinimized.Location = new System.Drawing.Point(3, 3);
-            this.launchMinimized.Name = "launchMinimized";
-            this.launchMinimized.Size = new System.Drawing.Size(151, 15);
-            this.launchMinimized.TabIndex = 0;
-            this.launchMinimized.Text = "Launch ALVR minimized";
-            this.launchMinimized.UseVisualStyleBackColor = true;
-            // 
-            // force60HzCheckBox
-            // 
-            this.force60HzCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.force60HzCheckBox.AutoSize = true;
-            this.force60HzCheckBox.Checked = global::ALVR.Properties.Settings.Default.force60Hz;
-            this.force60HzCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force60Hz", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.force60HzCheckBox.Location = new System.Drawing.Point(53, 85);
-            this.force60HzCheckBox.Name = "force60HzCheckBox";
-            this.force60HzCheckBox.Size = new System.Drawing.Size(81, 15);
-            this.force60HzCheckBox.TabIndex = 31;
-            this.force60HzCheckBox.Text = "Force 60Hz";
-            this.force60HzCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // suppressFrameDropCheckBox
-            // 
-            this.suppressFrameDropCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.suppressFrameDropCheckBox.AutoSize = true;
-            this.suppressFrameDropCheckBox.Checked = global::ALVR.Properties.Settings.Default.suppressFrameDrop;
-            this.suppressFrameDropCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "suppressFrameDrop", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.suppressFrameDropCheckBox.Location = new System.Drawing.Point(53, 106);
-            this.suppressFrameDropCheckBox.Name = "suppressFrameDropCheckBox";
-            this.suppressFrameDropCheckBox.Size = new System.Drawing.Size(132, 15);
-            this.suppressFrameDropCheckBox.TabIndex = 30;
-            this.suppressFrameDropCheckBox.Text = "Suppress frame drop";
-            this.suppressFrameDropCheckBox.UseVisualStyleBackColor = true;
-            this.suppressFrameDropCheckBox.CheckedChanged += new System.EventHandler(this.suppressFrameDropCheckBox_CheckedChanged);
-            // 
-            // disableThrottlingCheckBox
-            // 
-            this.disableThrottlingCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.disableThrottlingCheckBox.AutoSize = true;
-            this.disableThrottlingCheckBox.Checked = global::ALVR.Properties.Settings.Default.disableThrottling;
-            this.disableThrottlingCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableThrottling", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.disableThrottlingCheckBox.Location = new System.Drawing.Point(53, 127);
-            this.disableThrottlingCheckBox.Name = "disableThrottlingCheckBox";
-            this.disableThrottlingCheckBox.Size = new System.Drawing.Size(142, 15);
-            this.disableThrottlingCheckBox.TabIndex = 32;
-            this.disableThrottlingCheckBox.Text = "Disable send throttling";
-            this.disableThrottlingCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // disableController
-            // 
-            this.disableController.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.disableController.AutoSize = true;
-            this.disableController.Checked = global::ALVR.Properties.Settings.Default.disableController;
-            this.disableController.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableController", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.disableController.Location = new System.Drawing.Point(53, 148);
-            this.disableController.Name = "disableController";
-            this.disableController.Size = new System.Drawing.Size(115, 15);
-            this.disableController.TabIndex = 33;
-            this.disableController.Text = "Disable controller";
-            this.disableController.UseVisualStyleBackColor = true;
-            // 
-            // force3DOFCheckBox
-            // 
-            this.force3DOFCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.force3DOFCheckBox.AutoSize = true;
-            this.force3DOFCheckBox.Checked = global::ALVR.Properties.Settings.Default.force3DOF;
-            this.force3DOFCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force3DOF", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.force3DOFCheckBox.Location = new System.Drawing.Point(53, 169);
-            this.force3DOFCheckBox.Name = "force3DOFCheckBox";
-            this.force3DOFCheckBox.Size = new System.Drawing.Size(84, 15);
-            this.force3DOFCheckBox.TabIndex = 34;
-            this.force3DOFCheckBox.Text = "Force 3DOF";
-            this.force3DOFCheckBox.UseVisualStyleBackColor = true;
             // 
             // flowLayoutPanel15
             // 
             this.flowLayoutPanel15.AutoSize = true;
             this.flowLayoutPanel15.Controls.Add(this.aggressiveKeyframeResend);
             this.flowLayoutPanel15.Controls.Add(this.aggressiveKeyframeResendHelp);
-            this.flowLayoutPanel15.Location = new System.Drawing.Point(50, 187);
+            this.flowLayoutPanel15.Location = new System.Drawing.Point(5, 168);
             this.flowLayoutPanel15.Margin = new System.Windows.Forms.Padding(0);
             this.flowLayoutPanel15.Name = "flowLayoutPanel15";
             this.flowLayoutPanel15.Size = new System.Drawing.Size(194, 21);
             this.flowLayoutPanel15.TabIndex = 35;
-            // 
-            // aggressiveKeyframeResend
-            // 
-            this.aggressiveKeyframeResend.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.aggressiveKeyframeResend.AutoSize = true;
-            this.aggressiveKeyframeResend.Checked = global::ALVR.Properties.Settings.Default.aggressiveKeyframeResend;
-            this.aggressiveKeyframeResend.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "aggressiveKeyframeResend", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.aggressiveKeyframeResend.Location = new System.Drawing.Point(3, 3);
-            this.aggressiveKeyframeResend.Name = "aggressiveKeyframeResend";
-            this.aggressiveKeyframeResend.Size = new System.Drawing.Size(170, 15);
-            this.aggressiveKeyframeResend.TabIndex = 35;
-            this.aggressiveKeyframeResend.Text = "Aggressive keyframe resend";
-            this.aggressiveKeyframeResend.UseVisualStyleBackColor = true;
             // 
             // aggressiveKeyframeResendHelp
             // 
@@ -2203,12 +1807,14 @@
             // flowLayoutPanel17
             // 
             this.flowLayoutPanel17.AutoSize = true;
+            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel17, 2);
             this.flowLayoutPanel17.Controls.Add(this.metroLabel29);
             this.flowLayoutPanel17.Controls.Add(this.trackingFrameOffsetTextBox);
             this.flowLayoutPanel17.Controls.Add(this.saveTrackingFrameOffsetButton);
-            this.flowLayoutPanel17.Location = new System.Drawing.Point(3, 382);
+            this.flowLayoutPanel17.Controls.Add(this.metroLabel30);
+            this.flowLayoutPanel17.Location = new System.Drawing.Point(3, 376);
             this.flowLayoutPanel17.Name = "flowLayoutPanel17";
-            this.flowLayoutPanel17.Size = new System.Drawing.Size(324, 31);
+            this.flowLayoutPanel17.Size = new System.Drawing.Size(609, 38);
             this.flowLayoutPanel17.TabIndex = 0;
             this.flowLayoutPanel17.WrapContents = false;
             // 
@@ -2216,26 +1822,16 @@
             // 
             this.metroLabel29.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.metroLabel29.AutoSize = true;
-            this.metroLabel29.Location = new System.Drawing.Point(3, 6);
+            this.metroLabel29.Location = new System.Drawing.Point(3, 9);
             this.metroLabel29.Name = "metroLabel29";
             this.metroLabel29.Size = new System.Drawing.Size(129, 19);
             this.metroLabel29.TabIndex = 18;
             this.metroLabel29.Text = "TrackingFrameOffset";
             // 
-            // trackingFrameOffsetTextBox
-            // 
-            this.trackingFrameOffsetTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.trackingFrameOffsetTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "trackingFrameOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.trackingFrameOffsetTextBox.Location = new System.Drawing.Point(138, 3);
-            this.trackingFrameOffsetTextBox.Name = "trackingFrameOffsetTextBox";
-            this.trackingFrameOffsetTextBox.Size = new System.Drawing.Size(102, 25);
-            this.trackingFrameOffsetTextBox.TabIndex = 27;
-            this.trackingFrameOffsetTextBox.Text = global::ALVR.Properties.Settings.Default.trackingFrameOffset;
-            // 
             // saveTrackingFrameOffsetButton
             // 
             this.saveTrackingFrameOffsetButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.saveTrackingFrameOffsetButton.Location = new System.Drawing.Point(246, 3);
+            this.saveTrackingFrameOffsetButton.Location = new System.Drawing.Point(246, 6);
             this.saveTrackingFrameOffsetButton.Name = "saveTrackingFrameOffsetButton";
             this.saveTrackingFrameOffsetButton.Size = new System.Drawing.Size(75, 25);
             this.saveTrackingFrameOffsetButton.TabIndex = 28;
@@ -2245,9 +1841,9 @@
             // metroLabel30
             // 
             this.metroLabel30.AutoSize = true;
-            this.metroLabel30.Location = new System.Drawing.Point(467, 379);
+            this.metroLabel30.Location = new System.Drawing.Point(327, 0);
             this.metroLabel30.Name = "metroLabel30";
-            this.metroLabel30.Size = new System.Drawing.Size(185, 38);
+            this.metroLabel30.Size = new System.Drawing.Size(279, 38);
             this.metroLabel30.TabIndex = 18;
             this.metroLabel30.Text = "Try \"-1\" if you exceprience jerky head-tracking.\r\nPut \"0\" on if you have no probl" +
     "em.";
@@ -2260,7 +1856,7 @@
             this.flowLayoutPanel24.Controls.Add(this.connectCommandTextBox);
             this.flowLayoutPanel24.Controls.Add(this.refConnectCommandButton);
             this.flowLayoutPanel24.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel24.Location = new System.Drawing.Point(0, 317);
+            this.flowLayoutPanel24.Location = new System.Drawing.Point(0, 311);
             this.flowLayoutPanel24.Margin = new System.Windows.Forms.Padding(0);
             this.flowLayoutPanel24.Name = "flowLayoutPanel24";
             this.flowLayoutPanel24.Size = new System.Drawing.Size(655, 31);
@@ -2276,15 +1872,6 @@
             this.metroLabel27.TabIndex = 17;
             this.metroLabel27.Text = "On connect";
             // 
-            // connectCommandTextBox
-            // 
-            this.connectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "connectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.connectCommandTextBox.Location = new System.Drawing.Point(85, 3);
-            this.connectCommandTextBox.Name = "connectCommandTextBox";
-            this.connectCommandTextBox.Size = new System.Drawing.Size(351, 25);
-            this.connectCommandTextBox.TabIndex = 23;
-            this.connectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.connectCommand;
-            // 
             // refConnectCommandButton
             // 
             this.refConnectCommandButton.Location = new System.Drawing.Point(442, 3);
@@ -2298,11 +1885,12 @@
             // 
             this.metroLabel26.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.metroLabel26.AutoSize = true;
-            this.metroLabel26.Location = new System.Drawing.Point(3, 298);
+            this.metroLabel26.FontWeight = MetroFramework.MetroLabelWeight.Regular;
+            this.metroLabel26.Location = new System.Drawing.Point(3, 292);
             this.metroLabel26.Name = "metroLabel26";
-            this.metroLabel26.Size = new System.Drawing.Size(95, 19);
+            this.metroLabel26.Size = new System.Drawing.Size(101, 19);
             this.metroLabel26.TabIndex = 3;
-            this.metroLabel26.Text = "Run command";
+            this.metroLabel26.Text = "Run command:";
             // 
             // flowLayoutPanel25
             // 
@@ -2312,7 +1900,7 @@
             this.flowLayoutPanel25.Controls.Add(this.disconnectCommandTextBox);
             this.flowLayoutPanel25.Controls.Add(this.refDisconnectCommandButton);
             this.flowLayoutPanel25.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel25.Location = new System.Drawing.Point(0, 348);
+            this.flowLayoutPanel25.Location = new System.Drawing.Point(0, 342);
             this.flowLayoutPanel25.Margin = new System.Windows.Forms.Padding(0);
             this.flowLayoutPanel25.Name = "flowLayoutPanel25";
             this.flowLayoutPanel25.Size = new System.Drawing.Size(655, 31);
@@ -2328,15 +1916,6 @@
             this.metroLabel28.TabIndex = 17;
             this.metroLabel28.Text = "On disconnect";
             // 
-            // disconnectCommandTextBox
-            // 
-            this.disconnectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "disconnectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.disconnectCommandTextBox.Location = new System.Drawing.Point(101, 3);
-            this.disconnectCommandTextBox.Name = "disconnectCommandTextBox";
-            this.disconnectCommandTextBox.Size = new System.Drawing.Size(383, 25);
-            this.disconnectCommandTextBox.TabIndex = 25;
-            this.disconnectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.disconnectCommand;
-            // 
             // refDisconnectCommandButton
             // 
             this.refDisconnectCommandButton.Location = new System.Drawing.Point(490, 3);
@@ -2346,43 +1925,246 @@
             this.refDisconnectCommandButton.Text = "...";
             this.refDisconnectCommandButton.Click += new System.EventHandler(this.refDisconnectCommandButton_Click);
             // 
+            // tableLayoutPanel3
+            // 
+            this.tableLayoutPanel3.AutoSize = true;
+            this.tableLayoutPanel3.ColumnCount = 1;
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel43, 0, 4);
+            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel37, 0, 3);
+            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel38, 0, 2);
+            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel16, 0, 1);
+            this.tableLayoutPanel3.Controls.Add(this.metroLabel41, 0, 0);
+            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 13);
+            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            this.tableLayoutPanel3.RowCount = 6;
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(405, 276);
+            this.tableLayoutPanel3.TabIndex = 44;
+            // 
+            // flowLayoutPanel43
+            // 
+            this.flowLayoutPanel43.AutoSize = true;
+            this.flowLayoutPanel43.Controls.Add(this.metroLabel40);
+            this.flowLayoutPanel43.Controls.Add(this.controllerRotationOffsetHelp);
+            this.flowLayoutPanel43.Controls.Add(this.numericUpDown4);
+            this.flowLayoutPanel43.Controls.Add(this.numericUpDown5);
+            this.flowLayoutPanel43.Controls.Add(this.numericUpDown6);
+            this.flowLayoutPanel43.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel43.Location = new System.Drawing.Point(3, 132);
+            this.flowLayoutPanel43.Name = "flowLayoutPanel43";
+            this.flowLayoutPanel43.Size = new System.Drawing.Size(399, 26);
+            this.flowLayoutPanel43.TabIndex = 39;
+            // 
+            // metroLabel40
+            // 
+            this.metroLabel40.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel40.AutoSize = true;
+            this.metroLabel40.Location = new System.Drawing.Point(3, 3);
+            this.metroLabel40.Name = "metroLabel40";
+            this.metroLabel40.Size = new System.Drawing.Size(210, 19);
+            this.metroLabel40.TabIndex = 0;
+            this.metroLabel40.Text = "Left rotation offset (pitch, yaw, roll)";
+            // 
+            // controllerRotationOffsetHelp
+            // 
+            this.controllerRotationOffsetHelp.AutoSize = true;
+            this.controllerRotationOffsetHelp.Location = new System.Drawing.Point(219, 0);
+            this.controllerRotationOffsetHelp.Name = "controllerRotationOffsetHelp";
+            this.controllerRotationOffsetHelp.Size = new System.Drawing.Size(15, 19);
+            this.controllerRotationOffsetHelp.TabIndex = 52;
+            this.controllerRotationOffsetHelp.Text = "?";
+            this.controllerRotationOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
             // flowLayoutPanel37
             // 
-            this.flowLayoutPanel37.Controls.Add(this.flowLayoutPanel38);
+            this.flowLayoutPanel37.AutoSize = true;
+            this.flowLayoutPanel37.Controls.Add(this.metroLabel39);
+            this.flowLayoutPanel37.Controls.Add(this.controllerPositionOffsetHelp);
+            this.flowLayoutPanel37.Controls.Add(this.numericUpDown1);
+            this.flowLayoutPanel37.Controls.Add(this.numericUpDown2);
+            this.flowLayoutPanel37.Controls.Add(this.numericUpDown3);
             this.flowLayoutPanel37.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel37.Location = new System.Drawing.Point(3, 50);
+            this.flowLayoutPanel37.Location = new System.Drawing.Point(3, 100);
             this.flowLayoutPanel37.Name = "flowLayoutPanel37";
-            this.flowLayoutPanel37.Size = new System.Drawing.Size(458, 245);
-            this.flowLayoutPanel37.TabIndex = 43;
+            this.flowLayoutPanel37.Size = new System.Drawing.Size(399, 26);
+            this.flowLayoutPanel37.TabIndex = 38;
+            // 
+            // metroLabel39
+            // 
+            this.metroLabel39.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel39.AutoSize = true;
+            this.metroLabel39.Location = new System.Drawing.Point(3, 3);
+            this.metroLabel39.Name = "metroLabel39";
+            this.metroLabel39.Size = new System.Drawing.Size(159, 19);
+            this.metroLabel39.TabIndex = 0;
+            this.metroLabel39.Text = "Left position offset (x, y, z)";
+            // 
+            // controllerPositionOffsetHelp
+            // 
+            this.controllerPositionOffsetHelp.AutoSize = true;
+            this.controllerPositionOffsetHelp.Location = new System.Drawing.Point(168, 0);
+            this.controllerPositionOffsetHelp.Name = "controllerPositionOffsetHelp";
+            this.controllerPositionOffsetHelp.Size = new System.Drawing.Size(15, 19);
+            this.controllerPositionOffsetHelp.TabIndex = 52;
+            this.controllerPositionOffsetHelp.Text = "?";
+            this.controllerPositionOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // flowLayoutPanel38
             // 
+            this.flowLayoutPanel38.AutoSize = true;
             this.flowLayoutPanel38.Controls.Add(this.metroLabel36);
+            this.flowLayoutPanel38.Controls.Add(this.handTrackingModeHelp);
             this.flowLayoutPanel38.Controls.Add(this.controllerModeComboBox);
-            this.flowLayoutPanel38.Location = new System.Drawing.Point(3, 3);
+            this.flowLayoutPanel38.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel38.Location = new System.Drawing.Point(3, 59);
             this.flowLayoutPanel38.Name = "flowLayoutPanel38";
-            this.flowLayoutPanel38.Size = new System.Drawing.Size(448, 100);
+            this.flowLayoutPanel38.Size = new System.Drawing.Size(399, 35);
             this.flowLayoutPanel38.TabIndex = 0;
             // 
             // metroLabel36
             // 
+            this.metroLabel36.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.metroLabel36.AutoSize = true;
-            this.metroLabel36.Location = new System.Drawing.Point(3, 0);
+            this.metroLabel36.Location = new System.Drawing.Point(3, 8);
             this.metroLabel36.Name = "metroLabel36";
-            this.metroLabel36.Size = new System.Drawing.Size(107, 19);
+            this.metroLabel36.Size = new System.Drawing.Size(129, 19);
             this.metroLabel36.TabIndex = 0;
-            this.metroLabel36.Text = "Controller Mode";
+            this.metroLabel36.Text = "Hand tracking mode";
+            // 
+            // handTrackingModeHelp
+            // 
+            this.handTrackingModeHelp.AutoSize = true;
+            this.handTrackingModeHelp.Location = new System.Drawing.Point(138, 0);
+            this.handTrackingModeHelp.Name = "handTrackingModeHelp";
+            this.handTrackingModeHelp.Size = new System.Drawing.Size(15, 19);
+            this.handTrackingModeHelp.TabIndex = 53;
+            this.handTrackingModeHelp.Text = "?";
+            this.handTrackingModeHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // controllerModeComboBox
             // 
-            this.controllerModeComboBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.controllerModeComboBox.FormattingEnabled = true;
             this.controllerModeComboBox.ItemHeight = 23;
-            this.controllerModeComboBox.Location = new System.Drawing.Point(116, 3);
+            this.controllerModeComboBox.Location = new System.Drawing.Point(159, 3);
             this.controllerModeComboBox.Name = "controllerModeComboBox";
             this.controllerModeComboBox.Size = new System.Drawing.Size(232, 29);
             this.controllerModeComboBox.TabIndex = 1;
             this.controllerModeComboBox.SelectedIndexChanged += new System.EventHandler(this.metroComboBox1_SelectedIndexChanged);
+            // 
+            // flowLayoutPanel16
+            // 
+            this.flowLayoutPanel16.AutoSize = true;
+            this.flowLayoutPanel16.Controls.Add(this.metroLabel12);
+            this.flowLayoutPanel16.Controls.Add(this.controllerPoseOffset);
+            this.flowLayoutPanel16.Controls.Add(this.metroButton1);
+            this.flowLayoutPanel16.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel16.Location = new System.Drawing.Point(3, 22);
+            this.flowLayoutPanel16.Name = "flowLayoutPanel16";
+            this.flowLayoutPanel16.Size = new System.Drawing.Size(399, 31);
+            this.flowLayoutPanel16.TabIndex = 37;
+            this.flowLayoutPanel16.WrapContents = false;
+            // 
+            // metroLabel12
+            // 
+            this.metroLabel12.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel12.AutoSize = true;
+            this.metroLabel12.Location = new System.Drawing.Point(3, 6);
+            this.metroLabel12.Name = "metroLabel12";
+            this.metroLabel12.Size = new System.Drawing.Size(102, 19);
+            this.metroLabel12.TabIndex = 20;
+            this.metroLabel12.Text = "Pose time offset";
+            this.metroLabel12.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // metroButton1
+            // 
+            this.metroButton1.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroButton1.Location = new System.Drawing.Point(169, 3);
+            this.metroButton1.Name = "metroButton1";
+            this.metroButton1.Size = new System.Drawing.Size(75, 25);
+            this.metroButton1.TabIndex = 22;
+            this.metroButton1.Text = "Save";
+            this.metroButton1.Click += new System.EventHandler(this.metroButton1_Click);
+            // 
+            // metroLabel41
+            // 
+            this.metroLabel41.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel41.AutoSize = true;
+            this.metroLabel41.FontWeight = MetroFramework.MetroLabelWeight.Regular;
+            this.metroLabel41.Location = new System.Drawing.Point(3, 0);
+            this.metroLabel41.Name = "metroLabel41";
+            this.metroLabel41.Size = new System.Drawing.Size(125, 19);
+            this.metroLabel41.TabIndex = 40;
+            this.metroLabel41.Text = "Controller settings:";
+            this.metroLabel41.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // presetsTab
+            // 
+            this.presetsTab.Controls.Add(this.tableLayoutPanel2);
+            this.presetsTab.HorizontalScrollbarBarColor = true;
+            this.presetsTab.HorizontalScrollbarSize = 0;
+            this.presetsTab.Location = new System.Drawing.Point(4, 35);
+            this.presetsTab.Name = "presetsTab";
+            this.presetsTab.Size = new System.Drawing.Size(655, 417);
+            this.presetsTab.TabIndex = 9;
+            this.presetsTab.Text = "Presets";
+            this.presetsTab.VerticalScrollbarBarColor = true;
+            this.presetsTab.VerticalScrollbarSize = 0;
+            // 
+            // tableLayoutPanel2
+            // 
+            this.tableLayoutPanel2.BackColor = System.Drawing.SystemColors.Window;
+            this.tableLayoutPanel2.ColumnCount = 2;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel2.Controls.Add(this.metroLabel38, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel42, 1, 0);
+            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            this.tableLayoutPanel2.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
+            this.tableLayoutPanel2.RowCount = 2;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(655, 417);
+            this.tableLayoutPanel2.TabIndex = 9;
+            // 
+            // metroLabel38
+            // 
+            this.metroLabel38.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.metroLabel38.AutoSize = true;
+            this.metroLabel38.Location = new System.Drawing.Point(46, 19);
+            this.metroLabel38.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.metroLabel38.Name = "metroLabel38";
+            this.metroLabel38.Size = new System.Drawing.Size(54, 19);
+            this.metroLabel38.TabIndex = 27;
+            this.metroLabel38.Text = "General";
+            // 
+            // flowLayoutPanel42
+            // 
+            this.flowLayoutPanel42.AutoSize = true;
+            this.flowLayoutPanel42.Controls.Add(this.revertToDefaultButton);
+            this.flowLayoutPanel42.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel42.Location = new System.Drawing.Point(103, 13);
+            this.flowLayoutPanel42.Name = "flowLayoutPanel42";
+            this.flowLayoutPanel42.Size = new System.Drawing.Size(549, 31);
+            this.flowLayoutPanel42.TabIndex = 26;
+            // 
+            // revertToDefaultButton
+            // 
+            this.revertToDefaultButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.revertToDefaultButton.Location = new System.Drawing.Point(3, 3);
+            this.revertToDefaultButton.Name = "revertToDefaultButton";
+            this.revertToDefaultButton.Size = new System.Drawing.Size(163, 25);
+            this.revertToDefaultButton.TabIndex = 23;
+            this.revertToDefaultButton.Text = "Revert all settings to default";
+            this.revertToDefaultButton.Click += new System.EventHandler(this.revertToDefaultButton_Click);
             // 
             // debugTab
             // 
@@ -2548,18 +2330,6 @@
             this.flowLayoutPanel21.Size = new System.Drawing.Size(349, 209);
             this.flowLayoutPanel21.TabIndex = 15;
             // 
-            // debugLogCheckBox
-            // 
-            this.debugLogCheckBox.AutoSize = true;
-            this.debugLogCheckBox.Checked = global::ALVR.Properties.Settings.Default.debugLog;
-            this.debugLogCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "debugLog", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.debugLogCheckBox.Location = new System.Drawing.Point(3, 3);
-            this.debugLogCheckBox.Name = "debugLogCheckBox";
-            this.debugLogCheckBox.Size = new System.Drawing.Size(78, 15);
-            this.debugLogCheckBox.TabIndex = 9;
-            this.debugLogCheckBox.Text = "DebugLog";
-            this.debugLogCheckBox.UseVisualStyleBackColor = true;
-            // 
             // metroCheckBox1
             // 
             this.metroCheckBox1.AutoSize = true;
@@ -2569,18 +2339,6 @@
             this.metroCheckBox1.TabIndex = 9;
             this.metroCheckBox1.Text = "DebugFrameIndex";
             this.metroCheckBox1.UseVisualStyleBackColor = true;
-            // 
-            // debugCaptureOutputCheckBox
-            // 
-            this.debugCaptureOutputCheckBox.AutoSize = true;
-            this.debugCaptureOutputCheckBox.Checked = global::ALVR.Properties.Settings.Default.debugCaptureOutput;
-            this.debugCaptureOutputCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "debugCaptureOutput", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.debugCaptureOutputCheckBox.Location = new System.Drawing.Point(3, 24);
-            this.debugCaptureOutputCheckBox.Name = "debugCaptureOutputCheckBox";
-            this.debugCaptureOutputCheckBox.Size = new System.Drawing.Size(138, 15);
-            this.debugCaptureOutputCheckBox.TabIndex = 9;
-            this.debugCaptureOutputCheckBox.Text = "DebugCaptureOutput";
-            this.debugCaptureOutputCheckBox.UseVisualStyleBackColor = true;
             // 
             // metroCheckBox2
             // 
@@ -2830,67 +2588,571 @@
             this.notifyIcon1.Text = "ALVR";
             this.notifyIcon1.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.notifyIcon1_MouseDoubleClick);
             // 
-            // presetsTab
+            // sharpeningBox
             // 
-            this.presetsTab.Controls.Add(this.tableLayoutPanel2);
-            this.presetsTab.HorizontalScrollbarBarColor = true;
-            this.presetsTab.HorizontalScrollbarSize = 0;
-            this.presetsTab.Location = new System.Drawing.Point(4, 35);
-            this.presetsTab.Name = "presetsTab";
-            this.presetsTab.Size = new System.Drawing.Size(655, 417);
-            this.presetsTab.TabIndex = 9;
-            this.presetsTab.Text = "Presets";
-            this.presetsTab.VerticalScrollbarBarColor = true;
-            this.presetsTab.VerticalScrollbarSize = 0;
+            this.sharpeningBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "sharpening", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.sharpeningBox.DecimalPlaces = 2;
+            this.sharpeningBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.sharpeningBox.Location = new System.Drawing.Point(82, 3);
+            this.sharpeningBox.Maximum = new decimal(new int[] {
+            500,
+            0,
+            0,
+            131072});
+            this.sharpeningBox.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.sharpeningBox.Name = "sharpeningBox";
+            this.sharpeningBox.Size = new System.Drawing.Size(44, 20);
+            this.sharpeningBox.TabIndex = 44;
+            this.sharpeningBox.Value = global::ALVR.Properties.Settings.Default.sharpening;
             // 
-            // tableLayoutPanel2
+            // forceNV12
             // 
-            this.tableLayoutPanel2.BackColor = System.Drawing.SystemColors.Window;
-            this.tableLayoutPanel2.ColumnCount = 2;
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.Controls.Add(this.metroLabel38, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel42, 1, 0);
-            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
-            this.tableLayoutPanel2.RowCount = 2;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(655, 417);
-            this.tableLayoutPanel2.TabIndex = 9;
+            this.forceNV12.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.forceNV12.AutoSize = true;
+            this.forceNV12.Checked = global::ALVR.Properties.Settings.Default.nv12;
+            this.forceNV12.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "nv12", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.forceNV12.Location = new System.Drawing.Point(3, 3);
+            this.forceNV12.Margin = new System.Windows.Forms.Padding(3, 3, 0, 3);
+            this.forceNV12.Name = "forceNV12";
+            this.forceNV12.Size = new System.Drawing.Size(115, 15);
+            this.forceNV12.TabIndex = 35;
+            this.forceNV12.Text = "use custom NV12";
+            this.forceNV12.UseVisualStyleBackColor = true;
             // 
-            // revertToDefaultButton
+            // bitrateTrackBar
             // 
-            this.revertToDefaultButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.revertToDefaultButton.Location = new System.Drawing.Point(3, 3);
-            this.revertToDefaultButton.Name = "revertToDefaultButton";
-            this.revertToDefaultButton.Size = new System.Drawing.Size(163, 25);
-            this.revertToDefaultButton.TabIndex = 23;
-            this.revertToDefaultButton.Text = "Revert all settings to default";
-            this.revertToDefaultButton.Click += new System.EventHandler(this.revertToDefaultButton_Click);
+            this.bitrateTrackBar.BackColor = System.Drawing.Color.Transparent;
+            this.bitrateTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "bitrate", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.bitrateTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.bitrateTrackBar.Location = new System.Drawing.Point(233, 73);
+            this.bitrateTrackBar.Maximum = 250;
+            this.bitrateTrackBar.Minimum = 1;
+            this.bitrateTrackBar.Name = "bitrateTrackBar";
+            this.bitrateTrackBar.Size = new System.Drawing.Size(269, 25);
+            this.bitrateTrackBar.TabIndex = 2;
+            this.bitrateTrackBar.Text = "metroTrackBar1";
+            this.bitrateTrackBar.Value = global::ALVR.Properties.Settings.Default.bitrate;
+            this.bitrateTrackBar.ValueChanged += new System.EventHandler(this.bitrateTrackBar_ValueChanged);
+            this.bitrateTrackBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.bitrateTrackBar_Scroll);
             // 
-            // flowLayoutPanel42
+            // enableColorCorrectionCheckBox
             // 
-            this.flowLayoutPanel42.AutoSize = true;
-            this.flowLayoutPanel42.Controls.Add(this.revertToDefaultButton);
-            this.flowLayoutPanel42.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel42.Location = new System.Drawing.Point(103, 13);
-            this.flowLayoutPanel42.Name = "flowLayoutPanel42";
-            this.flowLayoutPanel42.Size = new System.Drawing.Size(549, 31);
-            this.flowLayoutPanel42.TabIndex = 26;
+            this.enableColorCorrectionCheckBox.AutoSize = true;
+            this.enableColorCorrectionCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableColorCorrection;
+            this.enableColorCorrectionCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableColorCorrection", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.enableColorCorrectionCheckBox.Location = new System.Drawing.Point(233, 295);
+            this.enableColorCorrectionCheckBox.Name = "enableColorCorrectionCheckBox";
+            this.enableColorCorrectionCheckBox.Size = new System.Drawing.Size(58, 15);
+            this.enableColorCorrectionCheckBox.TabIndex = 40;
+            this.enableColorCorrectionCheckBox.Text = "Enable";
+            this.enableColorCorrectionCheckBox.UseVisualStyleBackColor = true;
             // 
-            // metroLabel38
+            // bufferTrackBar
             // 
-            this.metroLabel38.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.metroLabel38.AutoSize = true;
-            this.metroLabel38.Location = new System.Drawing.Point(46, 19);
-            this.metroLabel38.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.metroLabel38.Name = "metroLabel38";
-            this.metroLabel38.Size = new System.Drawing.Size(54, 19);
-            this.metroLabel38.TabIndex = 27;
-            this.metroLabel38.Text = "General";
+            this.bufferTrackBar.BackColor = System.Drawing.Color.Transparent;
+            this.bufferTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "bufferOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.bufferTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.bufferTrackBar.Location = new System.Drawing.Point(233, 160);
+            this.bufferTrackBar.Minimum = -100;
+            this.bufferTrackBar.Name = "bufferTrackBar";
+            this.bufferTrackBar.Size = new System.Drawing.Size(269, 20);
+            this.bufferTrackBar.TabIndex = 2;
+            this.bufferTrackBar.Text = "metroTrackBar1";
+            this.bufferTrackBar.Value = global::ALVR.Properties.Settings.Default.bufferOffset;
+            this.bufferTrackBar.ValueChanged += new System.EventHandler(this.bufferTrackBar_ValueChanged);
+            this.bufferTrackBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.bufferTrackBar_Scroll);
+            // 
+            // foveationStrengthTrackBar
+            // 
+            this.foveationStrengthTrackBar.BackColor = System.Drawing.Color.Transparent;
+            this.foveationStrengthTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "foveationStrength", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.foveationStrengthTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.foveationStrengthTrackBar.LargeChange = 100;
+            this.foveationStrengthTrackBar.Location = new System.Drawing.Point(233, 240);
+            this.foveationStrengthTrackBar.Maximum = 500;
+            this.foveationStrengthTrackBar.MaximumSize = new System.Drawing.Size(0, 14);
+            this.foveationStrengthTrackBar.Name = "foveationStrengthTrackBar";
+            this.foveationStrengthTrackBar.Size = new System.Drawing.Size(269, 10);
+            this.foveationStrengthTrackBar.SmallChange = 10;
+            this.foveationStrengthTrackBar.TabIndex = 30;
+            this.foveationStrengthTrackBar.Text = "metroTrackBar1";
+            this.foveationStrengthTrackBar.Value = global::ALVR.Properties.Settings.Default.foveationStrength;
+            this.foveationStrengthTrackBar.ValueChanged += new System.EventHandler(this.FoveationStrengthTrackBar_ValueChanged);
+            // 
+            // foveationVerticalOffsetTrackBar
+            // 
+            this.foveationVerticalOffsetTrackBar.BackColor = System.Drawing.Color.Transparent;
+            this.foveationVerticalOffsetTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "foveationVerticalOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.foveationVerticalOffsetTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.foveationVerticalOffsetTrackBar.LargeChange = 2;
+            this.foveationVerticalOffsetTrackBar.Location = new System.Drawing.Point(233, 275);
+            this.foveationVerticalOffsetTrackBar.Maximum = 10;
+            this.foveationVerticalOffsetTrackBar.Minimum = -10;
+            this.foveationVerticalOffsetTrackBar.MouseWheelBarPartitions = 1;
+            this.foveationVerticalOffsetTrackBar.Name = "foveationVerticalOffsetTrackBar";
+            this.foveationVerticalOffsetTrackBar.Size = new System.Drawing.Size(269, 14);
+            this.foveationVerticalOffsetTrackBar.TabIndex = 34;
+            this.foveationVerticalOffsetTrackBar.Text = "metroTrackBar1";
+            this.foveationVerticalOffsetTrackBar.Value = global::ALVR.Properties.Settings.Default.foveationVerticalOffset;
+            this.foveationVerticalOffsetTrackBar.ValueChanged += new System.EventHandler(this.FoveationVerticalOffsetTrackBar_ValueChanged);
+            // 
+            // saturationBox
+            // 
+            this.saturationBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "saturation", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.saturationBox.DecimalPlaces = 2;
+            this.saturationBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.saturationBox.Location = new System.Drawing.Point(75, 3);
+            this.saturationBox.Maximum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.saturationBox.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            -2147483648});
+            this.saturationBox.Name = "saturationBox";
+            this.saturationBox.Size = new System.Drawing.Size(46, 20);
+            this.saturationBox.TabIndex = 48;
+            this.saturationBox.Value = global::ALVR.Properties.Settings.Default.saturation;
+            // 
+            // contrastBox
+            // 
+            this.contrastBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "contrast", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.contrastBox.DecimalPlaces = 2;
+            this.contrastBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.contrastBox.Location = new System.Drawing.Point(65, 3);
+            this.contrastBox.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.contrastBox.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.contrastBox.Name = "contrastBox";
+            this.contrastBox.Size = new System.Drawing.Size(45, 20);
+            this.contrastBox.TabIndex = 46;
+            this.contrastBox.Value = global::ALVR.Properties.Settings.Default.contrast;
+            // 
+            // brightnessBox
+            // 
+            this.brightnessBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "brightness", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.brightnessBox.DecimalPlaces = 2;
+            this.brightnessBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.brightnessBox.Location = new System.Drawing.Point(75, 3);
+            this.brightnessBox.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.brightnessBox.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.brightnessBox.Name = "brightnessBox";
+            this.brightnessBox.Size = new System.Drawing.Size(44, 20);
+            this.brightnessBox.TabIndex = 44;
+            this.brightnessBox.Value = global::ALVR.Properties.Settings.Default.brightness;
+            // 
+            // gammaBox
+            // 
+            this.gammaBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "gamma", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.gammaBox.DecimalPlaces = 2;
+            this.gammaBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.gammaBox.Location = new System.Drawing.Point(63, 3);
+            this.gammaBox.Maximum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.gammaBox.Name = "gammaBox";
+            this.gammaBox.Size = new System.Drawing.Size(45, 20);
+            this.gammaBox.TabIndex = 42;
+            this.gammaBox.Value = global::ALVR.Properties.Settings.Default.gamma;
+            // 
+            // soundCheckBox
+            // 
+            this.soundCheckBox.AutoSize = true;
+            this.soundCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableSound;
+            this.soundCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.soundCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableSound", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.soundCheckBox.Location = new System.Drawing.Point(3, 3);
+            this.soundCheckBox.Name = "soundCheckBox";
+            this.soundCheckBox.Size = new System.Drawing.Size(92, 15);
+            this.soundCheckBox.TabIndex = 2;
+            this.soundCheckBox.Text = "Steam sound";
+            this.soundCheckBox.UseVisualStyleBackColor = true;
+            this.soundCheckBox.CheckedChanged += new System.EventHandler(this.soundCheckBox_CheckedChanged);
+            // 
+            // streamMic
+            // 
+            this.streamMic.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.streamMic.AutoSize = true;
+            this.streamMic.Checked = global::ALVR.Properties.Settings.Default.streamMic;
+            this.streamMic.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "streamMic", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.streamMic.Location = new System.Drawing.Point(3, 73);
+            this.streamMic.Name = "streamMic";
+            this.streamMic.Size = new System.Drawing.Size(162, 15);
+            this.streamMic.TabIndex = 5;
+            this.streamMic.Text = "Stream Quest Microphone";
+            this.streamMic.UseVisualStyleBackColor = true;
+            this.streamMic.CheckedChanged += new System.EventHandler(this.metroCheckBox4_CheckedChanged);
+            // 
+            // defaultSoundDeviceCheckBox
+            // 
+            this.defaultSoundDeviceCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.defaultSoundDeviceCheckBox.AutoSize = true;
+            this.defaultSoundDeviceCheckBox.Checked = global::ALVR.Properties.Settings.Default.useDefaultSoundDevice;
+            this.defaultSoundDeviceCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.defaultSoundDeviceCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "useDefaultSoundDevice", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.defaultSoundDeviceCheckBox.Location = new System.Drawing.Point(20, 41);
+            this.defaultSoundDeviceCheckBox.Margin = new System.Windows.Forms.Padding(20, 3, 3, 3);
+            this.defaultSoundDeviceCheckBox.Name = "defaultSoundDeviceCheckBox";
+            this.defaultSoundDeviceCheckBox.Size = new System.Drawing.Size(119, 15);
+            this.defaultSoundDeviceCheckBox.TabIndex = 2;
+            this.defaultSoundDeviceCheckBox.Text = "Use default device";
+            this.defaultSoundDeviceCheckBox.UseVisualStyleBackColor = true;
+            this.defaultSoundDeviceCheckBox.CheckedChanged += new System.EventHandler(this.defaultSoundDeviceCheckBox_CheckedChanged);
+            // 
+            // onlySteamVRCheckBox
+            // 
+            this.onlySteamVRCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.onlySteamVRCheckBox.AutoSize = true;
+            this.onlySteamVRCheckBox.Checked = global::ALVR.Properties.Settings.Default.onlySteamVR;
+            this.onlySteamVRCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "onlySteamVR", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.onlySteamVRCheckBox.Location = new System.Drawing.Point(8, 3);
+            this.onlySteamVRCheckBox.Name = "onlySteamVRCheckBox";
+            this.onlySteamVRCheckBox.Size = new System.Drawing.Size(221, 15);
+            this.onlySteamVRCheckBox.TabIndex = 29;
+            this.onlySteamVRCheckBox.Text = "Launch only SteamVR without Steam.";
+            this.onlySteamVRCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // steamAutoLaunch
+            // 
+            this.steamAutoLaunch.AutoSize = true;
+            this.steamAutoLaunch.Checked = global::ALVR.Properties.Settings.Default.steamAutolaunch;
+            this.steamAutoLaunch.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "steamAutolaunch", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.steamAutoLaunch.Location = new System.Drawing.Point(3, 3);
+            this.steamAutoLaunch.Name = "steamAutoLaunch";
+            this.steamAutoLaunch.Size = new System.Drawing.Size(206, 15);
+            this.steamAutoLaunch.TabIndex = 36;
+            this.steamAutoLaunch.Text = "Launch SteamVR on HMD connect";
+            this.steamAutoLaunch.UseVisualStyleBackColor = true;
+            // 
+            // launchMinimized
+            // 
+            this.launchMinimized.AutoSize = true;
+            this.launchMinimized.Checked = global::ALVR.Properties.Settings.Default.launchMinimized;
+            this.launchMinimized.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "launchMinimized", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.launchMinimized.Location = new System.Drawing.Point(3, 3);
+            this.launchMinimized.Name = "launchMinimized";
+            this.launchMinimized.Size = new System.Drawing.Size(151, 15);
+            this.launchMinimized.TabIndex = 0;
+            this.launchMinimized.Text = "Launch ALVR minimized";
+            this.launchMinimized.UseVisualStyleBackColor = true;
+            // 
+            // force60HzCheckBox
+            // 
+            this.force60HzCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.force60HzCheckBox.AutoSize = true;
+            this.force60HzCheckBox.Checked = global::ALVR.Properties.Settings.Default.force60Hz;
+            this.force60HzCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force60Hz", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.force60HzCheckBox.Location = new System.Drawing.Point(8, 66);
+            this.force60HzCheckBox.Name = "force60HzCheckBox";
+            this.force60HzCheckBox.Size = new System.Drawing.Size(81, 15);
+            this.force60HzCheckBox.TabIndex = 31;
+            this.force60HzCheckBox.Text = "Force 60Hz";
+            this.force60HzCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // suppressFrameDropCheckBox
+            // 
+            this.suppressFrameDropCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.suppressFrameDropCheckBox.AutoSize = true;
+            this.suppressFrameDropCheckBox.Checked = global::ALVR.Properties.Settings.Default.suppressFrameDrop;
+            this.suppressFrameDropCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "suppressFrameDrop", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.suppressFrameDropCheckBox.Location = new System.Drawing.Point(8, 87);
+            this.suppressFrameDropCheckBox.Name = "suppressFrameDropCheckBox";
+            this.suppressFrameDropCheckBox.Size = new System.Drawing.Size(132, 15);
+            this.suppressFrameDropCheckBox.TabIndex = 30;
+            this.suppressFrameDropCheckBox.Text = "Suppress frame drop";
+            this.suppressFrameDropCheckBox.UseVisualStyleBackColor = true;
+            this.suppressFrameDropCheckBox.CheckedChanged += new System.EventHandler(this.suppressFrameDropCheckBox_CheckedChanged);
+            // 
+            // disableThrottlingCheckBox
+            // 
+            this.disableThrottlingCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.disableThrottlingCheckBox.AutoSize = true;
+            this.disableThrottlingCheckBox.Checked = global::ALVR.Properties.Settings.Default.disableThrottling;
+            this.disableThrottlingCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableThrottling", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.disableThrottlingCheckBox.Location = new System.Drawing.Point(8, 108);
+            this.disableThrottlingCheckBox.Name = "disableThrottlingCheckBox";
+            this.disableThrottlingCheckBox.Size = new System.Drawing.Size(142, 15);
+            this.disableThrottlingCheckBox.TabIndex = 32;
+            this.disableThrottlingCheckBox.Text = "Disable send throttling";
+            this.disableThrottlingCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // disableController
+            // 
+            this.disableController.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.disableController.AutoSize = true;
+            this.disableController.Checked = global::ALVR.Properties.Settings.Default.disableController;
+            this.disableController.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableController", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.disableController.Location = new System.Drawing.Point(8, 129);
+            this.disableController.Name = "disableController";
+            this.disableController.Size = new System.Drawing.Size(115, 15);
+            this.disableController.TabIndex = 33;
+            this.disableController.Text = "Disable controller";
+            this.disableController.UseVisualStyleBackColor = true;
+            // 
+            // force3DOFCheckBox
+            // 
+            this.force3DOFCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.force3DOFCheckBox.AutoSize = true;
+            this.force3DOFCheckBox.Checked = global::ALVR.Properties.Settings.Default.force3DOF;
+            this.force3DOFCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force3DOF", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.force3DOFCheckBox.Location = new System.Drawing.Point(8, 150);
+            this.force3DOFCheckBox.Name = "force3DOFCheckBox";
+            this.force3DOFCheckBox.Size = new System.Drawing.Size(84, 15);
+            this.force3DOFCheckBox.TabIndex = 34;
+            this.force3DOFCheckBox.Text = "Force 3DOF";
+            this.force3DOFCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // aggressiveKeyframeResend
+            // 
+            this.aggressiveKeyframeResend.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.aggressiveKeyframeResend.AutoSize = true;
+            this.aggressiveKeyframeResend.Checked = global::ALVR.Properties.Settings.Default.aggressiveKeyframeResend;
+            this.aggressiveKeyframeResend.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "aggressiveKeyframeResend", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.aggressiveKeyframeResend.Location = new System.Drawing.Point(3, 3);
+            this.aggressiveKeyframeResend.Name = "aggressiveKeyframeResend";
+            this.aggressiveKeyframeResend.Size = new System.Drawing.Size(170, 15);
+            this.aggressiveKeyframeResend.TabIndex = 35;
+            this.aggressiveKeyframeResend.Text = "Aggressive keyframe resend";
+            this.aggressiveKeyframeResend.UseVisualStyleBackColor = true;
+            // 
+            // trackingFrameOffsetTextBox
+            // 
+            this.trackingFrameOffsetTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.trackingFrameOffsetTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "trackingFrameOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.trackingFrameOffsetTextBox.Location = new System.Drawing.Point(138, 6);
+            this.trackingFrameOffsetTextBox.Name = "trackingFrameOffsetTextBox";
+            this.trackingFrameOffsetTextBox.Size = new System.Drawing.Size(102, 25);
+            this.trackingFrameOffsetTextBox.TabIndex = 27;
+            this.trackingFrameOffsetTextBox.Text = global::ALVR.Properties.Settings.Default.trackingFrameOffset;
+            // 
+            // connectCommandTextBox
+            // 
+            this.connectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "connectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.connectCommandTextBox.Location = new System.Drawing.Point(85, 3);
+            this.connectCommandTextBox.Name = "connectCommandTextBox";
+            this.connectCommandTextBox.Size = new System.Drawing.Size(351, 25);
+            this.connectCommandTextBox.TabIndex = 23;
+            this.connectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.connectCommand;
+            // 
+            // disconnectCommandTextBox
+            // 
+            this.disconnectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "disconnectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.disconnectCommandTextBox.Location = new System.Drawing.Point(101, 3);
+            this.disconnectCommandTextBox.Name = "disconnectCommandTextBox";
+            this.disconnectCommandTextBox.Size = new System.Drawing.Size(383, 25);
+            this.disconnectCommandTextBox.TabIndex = 25;
+            this.disconnectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.disconnectCommand;
+            // 
+            // numericUpDown4
+            // 
+            this.numericUpDown4.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPitchOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown4.Location = new System.Drawing.Point(240, 3);
+            this.numericUpDown4.Maximum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            0});
+            this.numericUpDown4.Minimum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            -2147483648});
+            this.numericUpDown4.Name = "numericUpDown4";
+            this.numericUpDown4.Size = new System.Drawing.Size(45, 20);
+            this.numericUpDown4.TabIndex = 54;
+            this.numericUpDown4.Value = global::ALVR.Properties.Settings.Default.leftControllerPitchOffset;
+            // 
+            // numericUpDown5
+            // 
+            this.numericUpDown5.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerYawOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown5.Location = new System.Drawing.Point(291, 3);
+            this.numericUpDown5.Maximum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            0});
+            this.numericUpDown5.Minimum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            -2147483648});
+            this.numericUpDown5.Name = "numericUpDown5";
+            this.numericUpDown5.Size = new System.Drawing.Size(45, 20);
+            this.numericUpDown5.TabIndex = 55;
+            this.numericUpDown5.Value = global::ALVR.Properties.Settings.Default.leftControllerYawOffset;
+            // 
+            // numericUpDown6
+            // 
+            this.numericUpDown6.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerRollOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown6.Location = new System.Drawing.Point(342, 3);
+            this.numericUpDown6.Maximum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            0});
+            this.numericUpDown6.Minimum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            -2147483648});
+            this.numericUpDown6.Name = "numericUpDown6";
+            this.numericUpDown6.Size = new System.Drawing.Size(45, 20);
+            this.numericUpDown6.TabIndex = 56;
+            this.numericUpDown6.Value = global::ALVR.Properties.Settings.Default.leftControllerRollOffset;
+            // 
+            // numericUpDown1
+            // 
+            this.numericUpDown1.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetX", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown1.DecimalPlaces = 3;
+            this.numericUpDown1.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            196608});
+            this.numericUpDown1.Location = new System.Drawing.Point(189, 3);
+            this.numericUpDown1.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.numericUpDown1.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.numericUpDown1.Name = "numericUpDown1";
+            this.numericUpDown1.Size = new System.Drawing.Size(55, 20);
+            this.numericUpDown1.TabIndex = 53;
+            this.numericUpDown1.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetX;
+            // 
+            // numericUpDown2
+            // 
+            this.numericUpDown2.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetY", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown2.DecimalPlaces = 3;
+            this.numericUpDown2.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            196608});
+            this.numericUpDown2.Location = new System.Drawing.Point(250, 3);
+            this.numericUpDown2.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.numericUpDown2.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.numericUpDown2.Name = "numericUpDown2";
+            this.numericUpDown2.Size = new System.Drawing.Size(55, 20);
+            this.numericUpDown2.TabIndex = 54;
+            this.numericUpDown2.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetY;
+            // 
+            // numericUpDown3
+            // 
+            this.numericUpDown3.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetZ", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown3.DecimalPlaces = 3;
+            this.numericUpDown3.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            196608});
+            this.numericUpDown3.Location = new System.Drawing.Point(311, 3);
+            this.numericUpDown3.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.numericUpDown3.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.numericUpDown3.Name = "numericUpDown3";
+            this.numericUpDown3.Size = new System.Drawing.Size(55, 20);
+            this.numericUpDown3.TabIndex = 55;
+            this.numericUpDown3.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetZ;
+            // 
+            // controllerPoseOffset
+            // 
+            this.controllerPoseOffset.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.controllerPoseOffset.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "controllerPoseOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.controllerPoseOffset.Location = new System.Drawing.Point(111, 6);
+            this.controllerPoseOffset.Name = "controllerPoseOffset";
+            this.controllerPoseOffset.Size = new System.Drawing.Size(52, 19);
+            this.controllerPoseOffset.TabIndex = 21;
+            this.controllerPoseOffset.Text = global::ALVR.Properties.Settings.Default.controllerPoseOffset;
+            this.controllerPoseOffset.Click += new System.EventHandler(this.controllerPoseOffset_Click);
+            // 
+            // debugLogCheckBox
+            // 
+            this.debugLogCheckBox.AutoSize = true;
+            this.debugLogCheckBox.Checked = global::ALVR.Properties.Settings.Default.debugLog;
+            this.debugLogCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "debugLog", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.debugLogCheckBox.Location = new System.Drawing.Point(3, 3);
+            this.debugLogCheckBox.Name = "debugLogCheckBox";
+            this.debugLogCheckBox.Size = new System.Drawing.Size(78, 15);
+            this.debugLogCheckBox.TabIndex = 9;
+            this.debugLogCheckBox.Text = "DebugLog";
+            this.debugLogCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // debugCaptureOutputCheckBox
+            // 
+            this.debugCaptureOutputCheckBox.AutoSize = true;
+            this.debugCaptureOutputCheckBox.Checked = global::ALVR.Properties.Settings.Default.debugCaptureOutput;
+            this.debugCaptureOutputCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "debugCaptureOutput", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.debugCaptureOutputCheckBox.Location = new System.Drawing.Point(3, 24);
+            this.debugCaptureOutputCheckBox.Name = "debugCaptureOutputCheckBox";
+            this.debugCaptureOutputCheckBox.Size = new System.Drawing.Size(138, 15);
+            this.debugCaptureOutputCheckBox.TabIndex = 9;
+            this.debugCaptureOutputCheckBox.Text = "DebugCaptureOutput";
+            this.debugCaptureOutputCheckBox.UseVisualStyleBackColor = true;
             // 
             // Launcher
             // 
@@ -2931,7 +3193,6 @@
             this.flowLayoutPanel39.ResumeLayout(false);
             this.flowLayoutPanel40.ResumeLayout(false);
             this.flowLayoutPanel40.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.sharpeningBox)).EndInit();
             this.flowLayoutPanel2.ResumeLayout(false);
             this.flowLayoutPanel2.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
@@ -2959,17 +3220,13 @@
             this.flowLayoutPanel32.ResumeLayout(false);
             this.flowLayoutPanel28.ResumeLayout(false);
             this.flowLayoutPanel28.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.saturationBox)).EndInit();
             this.flowLayoutPanel30.ResumeLayout(false);
             this.flowLayoutPanel30.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.contrastBox)).EndInit();
             this.flowLayoutPanel33.ResumeLayout(false);
             this.flowLayoutPanel29.ResumeLayout(false);
             this.flowLayoutPanel29.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.brightnessBox)).EndInit();
             this.flowLayoutPanel31.ResumeLayout(false);
             this.flowLayoutPanel31.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.gammaBox)).EndInit();
             this.flowLayoutPanel34.ResumeLayout(false);
             this.flowLayoutPanel34.PerformLayout();
             this.soundTab.ResumeLayout(false);
@@ -2982,8 +3239,6 @@
             this.otherTab.ResumeLayout(false);
             this.tableLayoutPanel11.ResumeLayout(false);
             this.tableLayoutPanel11.PerformLayout();
-            this.flowLayoutPanel16.ResumeLayout(false);
-            this.flowLayoutPanel16.PerformLayout();
             this.flowLayoutPanel26.ResumeLayout(false);
             this.flowLayoutPanel26.PerformLayout();
             this.flowLayoutPanel35.ResumeLayout(false);
@@ -2998,9 +3253,20 @@
             this.flowLayoutPanel24.PerformLayout();
             this.flowLayoutPanel25.ResumeLayout(false);
             this.flowLayoutPanel25.PerformLayout();
+            this.tableLayoutPanel3.ResumeLayout(false);
+            this.tableLayoutPanel3.PerformLayout();
+            this.flowLayoutPanel43.ResumeLayout(false);
+            this.flowLayoutPanel43.PerformLayout();
             this.flowLayoutPanel37.ResumeLayout(false);
+            this.flowLayoutPanel37.PerformLayout();
             this.flowLayoutPanel38.ResumeLayout(false);
             this.flowLayoutPanel38.PerformLayout();
+            this.flowLayoutPanel16.ResumeLayout(false);
+            this.flowLayoutPanel16.PerformLayout();
+            this.presetsTab.ResumeLayout(false);
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            this.flowLayoutPanel42.ResumeLayout(false);
             this.debugTab.ResumeLayout(false);
             this.tableLayoutPanel14.ResumeLayout(false);
             this.tableLayoutPanel14.PerformLayout();
@@ -3019,10 +3285,17 @@
             this.flowLayoutPanel23.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.resolutionBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            this.presetsTab.ResumeLayout(false);
-            this.tableLayoutPanel2.ResumeLayout(false);
-            this.tableLayoutPanel2.PerformLayout();
-            this.flowLayoutPanel42.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.sharpeningBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.saturationBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.contrastBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.brightnessBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.gammaBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown4)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown5)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown6)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -3217,10 +3490,6 @@
         private MetroFramework.Controls.MetroLabel autoLaunchHelp;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel36;
         private MetroFramework.Controls.MetroCheckBox launchMinimized;
-		private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel37;
-		private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel38;
-		private MetroFramework.Controls.MetroLabel metroLabel36;
-		private MetroFramework.Controls.MetroComboBox controllerModeComboBox;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel39;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel40;
         private MetroFramework.Controls.MetroLabel metroLabel37;
@@ -3231,6 +3500,24 @@
         private MetroFramework.Controls.MetroButton revertToDefaultButton;
         private MetroFramework.Controls.MetroLabel metroLabel38;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel42;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel43;
+        private MetroFramework.Controls.MetroLabel metroLabel40;
+        private MetroFramework.Controls.MetroLabel controllerRotationOffsetHelp;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel37;
+        private MetroFramework.Controls.MetroLabel metroLabel39;
+        private MetroFramework.Controls.MetroLabel controllerPositionOffsetHelp;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel38;
+        private MetroFramework.Controls.MetroLabel metroLabel36;
+        private MetroFramework.Controls.MetroLabel handTrackingModeHelp;
+        private MetroFramework.Controls.MetroComboBox controllerModeComboBox;
+        private MetroFramework.Controls.MetroLabel metroLabel41;
+        private System.Windows.Forms.NumericUpDown numericUpDown1;
+        private System.Windows.Forms.NumericUpDown numericUpDown4;
+        private System.Windows.Forms.NumericUpDown numericUpDown5;
+        private System.Windows.Forms.NumericUpDown numericUpDown6;
+        private System.Windows.Forms.NumericUpDown numericUpDown2;
+        private System.Windows.Forms.NumericUpDown numericUpDown3;
     }
 }
 

--- a/ALVR/Launcher.Designer.cs
+++ b/ALVR/Launcher.Designer.cs
@@ -68,22 +68,86 @@
             this.closeServerButton = new MetroFramework.Controls.MetroButton();
             this.connectedLabel = new MetroFramework.Controls.MetroLabel();
             this.autoConnectCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.presetsTab = new MetroFramework.Controls.MetroTabPage();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel44 = new System.Windows.Forms.FlowLayoutPanel();
+            this.fixBoneworksControllersButton = new MetroFramework.Controls.MetroButton();
+            this.metroLabel38 = new MetroFramework.Controls.MetroLabel();
+            this.flowLayoutPanel42 = new System.Windows.Forms.FlowLayoutPanel();
+            this.revertToDefaultButton = new MetroFramework.Controls.MetroButton();
+            this.metroLabel42 = new MetroFramework.Controls.MetroLabel();
+            this.otherTab = new MetroFramework.Controls.MetroTabPage();
+            this.tableLayoutPanel11 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel26 = new System.Windows.Forms.FlowLayoutPanel();
+            this.onlySteamVRCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.flowLayoutPanel35 = new System.Windows.Forms.FlowLayoutPanel();
+            this.steamAutoLaunch = new MetroFramework.Controls.MetroCheckBox();
+            this.autoLaunchHelp = new MetroFramework.Controls.MetroLabel();
+            this.flowLayoutPanel36 = new System.Windows.Forms.FlowLayoutPanel();
+            this.launchMinimized = new MetroFramework.Controls.MetroCheckBox();
+            this.force60HzCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.suppressFrameDropCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.disableThrottlingCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.disableController = new MetroFramework.Controls.MetroCheckBox();
+            this.force3DOFCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.flowLayoutPanel15 = new System.Windows.Forms.FlowLayoutPanel();
+            this.aggressiveKeyframeResend = new MetroFramework.Controls.MetroCheckBox();
+            this.aggressiveKeyframeResendHelp = new MetroFramework.Controls.MetroLabel();
+            this.flowLayoutPanel17 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel29 = new MetroFramework.Controls.MetroLabel();
+            this.trackingFrameOffsetTextBox = new MetroFramework.Controls.MetroTextBox();
+            this.saveTrackingFrameOffsetButton = new MetroFramework.Controls.MetroButton();
+            this.metroLabel30 = new MetroFramework.Controls.MetroLabel();
+            this.flowLayoutPanel24 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel27 = new MetroFramework.Controls.MetroLabel();
+            this.connectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
+            this.refConnectCommandButton = new MetroFramework.Controls.MetroButton();
+            this.metroLabel26 = new MetroFramework.Controls.MetroLabel();
+            this.flowLayoutPanel25 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel28 = new MetroFramework.Controls.MetroLabel();
+            this.disconnectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
+            this.refDisconnectCommandButton = new MetroFramework.Controls.MetroButton();
+            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel43 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel40 = new MetroFramework.Controls.MetroLabel();
+            this.controllerRotationOffsetHelp = new MetroFramework.Controls.MetroLabel();
+            this.numericUpDown4 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown5 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown6 = new System.Windows.Forms.NumericUpDown();
+            this.flowLayoutPanel37 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel39 = new MetroFramework.Controls.MetroLabel();
+            this.controllerPositionOffsetHelp = new MetroFramework.Controls.MetroLabel();
+            this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown2 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown3 = new System.Windows.Forms.NumericUpDown();
+            this.flowLayoutPanel38 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel36 = new MetroFramework.Controls.MetroLabel();
+            this.handTrackingModeHelp = new MetroFramework.Controls.MetroLabel();
+            this.controllerModeComboBox = new MetroFramework.Controls.MetroComboBox();
+            this.flowLayoutPanel16 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel12 = new MetroFramework.Controls.MetroLabel();
+            this.controllerPoseOffset = new MetroFramework.Controls.MetroTextBox();
+            this.metroButton1 = new MetroFramework.Controls.MetroButton();
+            this.metroLabel41 = new MetroFramework.Controls.MetroLabel();
             this.videoTab = new MetroFramework.Controls.MetroTabPage();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel39 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel40 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel37 = new MetroFramework.Controls.MetroLabel();
+            this.sharpeningBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel41 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel31 = new MetroFramework.Controls.MetroLabel();
             this.codecHelp = new MetroFramework.Controls.MetroLabel();
             this.codecComboBox = new MetroFramework.Controls.MetroComboBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.forceNV12 = new MetroFramework.Controls.MetroCheckBox();
             this.nv12Tooltip = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel3 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel7 = new MetroFramework.Controls.MetroLabel();
             this.bitrateHelp = new MetroFramework.Controls.MetroLabel();
             this.bitrateLabel = new MetroFramework.Controls.MetroLabel();
+            this.bitrateTrackBar = new MetroFramework.Controls.MetroTrackBar();
             this.flowLayoutPanel5 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel10 = new MetroFramework.Controls.MetroLabel();
             this.resolutionHelp = new MetroFramework.Controls.MetroLabel();
@@ -96,6 +160,8 @@
             this.metroLabel19 = new MetroFramework.Controls.MetroLabel();
             this.bufferLabel = new MetroFramework.Controls.MetroLabel();
             this.bufferHelp = new MetroFramework.Controls.MetroLabel();
+            this.enableColorCorrectionCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.bufferTrackBar = new MetroFramework.Controls.MetroTrackBar();
             this.flowLayoutPanel9 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel21 = new MetroFramework.Controls.MetroLabel();
             this.ffrHelp = new MetroFramework.Controls.MetroLabel();
@@ -104,9 +170,11 @@
             this.ffrMeanLabel = new MetroFramework.Controls.MetroLabel();
             this.ffrStrengthHelp = new MetroFramework.Controls.MetroLabel();
             this.foveationStrengthLabel = new MetroFramework.Controls.MetroLabel();
+            this.foveationStrengthTrackBar = new MetroFramework.Controls.MetroTrackBar();
             this.flowLayoutPanel11 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel23 = new MetroFramework.Controls.MetroLabel();
             this.ffrVerticalOffsetHelp = new MetroFramework.Controls.MetroLabel();
+            this.foveationVerticalOffsetTrackBar = new MetroFramework.Controls.MetroTrackBar();
             this.foveationVerticalOffsetLabel = new MetroFramework.Controls.MetroLabel();
             this.panel1 = new System.Windows.Forms.Panel();
             this.metroLabel34 = new MetroFramework.Controls.MetroLabel();
@@ -122,63 +190,31 @@
             this.flowLayoutPanel32 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel28 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel33 = new MetroFramework.Controls.MetroLabel();
+            this.saturationBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel30 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel25 = new MetroFramework.Controls.MetroLabel();
+            this.contrastBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel33 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel29 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel32 = new MetroFramework.Controls.MetroLabel();
+            this.brightnessBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel31 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel24 = new MetroFramework.Controls.MetroLabel();
+            this.gammaBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel34 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel35 = new MetroFramework.Controls.MetroLabel();
             this.bufferOffsetLabel = new MetroFramework.Controls.MetroLabel();
             this.soundTab = new MetroFramework.Controls.MetroTabPage();
             this.tableLayoutPanel9 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel13 = new System.Windows.Forms.FlowLayoutPanel();
+            this.soundCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.noSoundDeviceLabel = new MetroFramework.Controls.MetroLabel();
             this.soundDeviceComboBox = new MetroFramework.Controls.MetroComboBox();
+            this.streamMic = new MetroFramework.Controls.MetroCheckBox();
             this.flowLayoutPanel14 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel20 = new MetroFramework.Controls.MetroLabel();
             this.metroLink1 = new MetroFramework.Controls.MetroLink();
-            this.otherTab = new MetroFramework.Controls.MetroTabPage();
-            this.tableLayoutPanel11 = new System.Windows.Forms.TableLayoutPanel();
-            this.flowLayoutPanel26 = new System.Windows.Forms.FlowLayoutPanel();
-            this.flowLayoutPanel35 = new System.Windows.Forms.FlowLayoutPanel();
-            this.autoLaunchHelp = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel36 = new System.Windows.Forms.FlowLayoutPanel();
-            this.flowLayoutPanel15 = new System.Windows.Forms.FlowLayoutPanel();
-            this.aggressiveKeyframeResendHelp = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel17 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel29 = new MetroFramework.Controls.MetroLabel();
-            this.saveTrackingFrameOffsetButton = new MetroFramework.Controls.MetroButton();
-            this.metroLabel30 = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel24 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel27 = new MetroFramework.Controls.MetroLabel();
-            this.refConnectCommandButton = new MetroFramework.Controls.MetroButton();
-            this.metroLabel26 = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel25 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel28 = new MetroFramework.Controls.MetroLabel();
-            this.refDisconnectCommandButton = new MetroFramework.Controls.MetroButton();
-            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-            this.flowLayoutPanel43 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel40 = new MetroFramework.Controls.MetroLabel();
-            this.controllerRotationOffsetHelp = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel37 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel39 = new MetroFramework.Controls.MetroLabel();
-            this.controllerPositionOffsetHelp = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel38 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel36 = new MetroFramework.Controls.MetroLabel();
-            this.handTrackingModeHelp = new MetroFramework.Controls.MetroLabel();
-            this.controllerModeComboBox = new MetroFramework.Controls.MetroComboBox();
-            this.flowLayoutPanel16 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel12 = new MetroFramework.Controls.MetroLabel();
-            this.metroButton1 = new MetroFramework.Controls.MetroButton();
-            this.metroLabel41 = new MetroFramework.Controls.MetroLabel();
-            this.presetsTab = new MetroFramework.Controls.MetroTabPage();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.metroLabel38 = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel42 = new System.Windows.Forms.FlowLayoutPanel();
-            this.revertToDefaultButton = new MetroFramework.Controls.MetroButton();
+            this.defaultSoundDeviceCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.debugTab = new MetroFramework.Controls.MetroTabPage();
             this.tableLayoutPanel14 = new System.Windows.Forms.TableLayoutPanel();
             this.metroLabel5 = new MetroFramework.Controls.MetroLabel();
@@ -193,7 +229,9 @@
             this.captureLayerDDSButton = new MetroFramework.Controls.MetroButton();
             this.packetlossButton = new MetroFramework.Controls.MetroButton();
             this.flowLayoutPanel21 = new System.Windows.Forms.FlowLayoutPanel();
+            this.debugLogCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.metroCheckBox1 = new MetroFramework.Controls.MetroCheckBox();
+            this.debugCaptureOutputCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.metroCheckBox2 = new MetroFramework.Controls.MetroCheckBox();
             this.metroCheckBox3 = new MetroFramework.Controls.MetroCheckBox();
             this.metroButton5 = new MetroFramework.Controls.MetroButton();
@@ -218,41 +256,6 @@
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
             this.notifyIcon1 = new System.Windows.Forms.NotifyIcon(this.components);
-            this.sharpeningBox = new System.Windows.Forms.NumericUpDown();
-            this.forceNV12 = new MetroFramework.Controls.MetroCheckBox();
-            this.bitrateTrackBar = new MetroFramework.Controls.MetroTrackBar();
-            this.enableColorCorrectionCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.bufferTrackBar = new MetroFramework.Controls.MetroTrackBar();
-            this.foveationStrengthTrackBar = new MetroFramework.Controls.MetroTrackBar();
-            this.foveationVerticalOffsetTrackBar = new MetroFramework.Controls.MetroTrackBar();
-            this.saturationBox = new System.Windows.Forms.NumericUpDown();
-            this.contrastBox = new System.Windows.Forms.NumericUpDown();
-            this.brightnessBox = new System.Windows.Forms.NumericUpDown();
-            this.gammaBox = new System.Windows.Forms.NumericUpDown();
-            this.soundCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.streamMic = new MetroFramework.Controls.MetroCheckBox();
-            this.defaultSoundDeviceCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.onlySteamVRCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.steamAutoLaunch = new MetroFramework.Controls.MetroCheckBox();
-            this.launchMinimized = new MetroFramework.Controls.MetroCheckBox();
-            this.force60HzCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.suppressFrameDropCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.disableThrottlingCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.disableController = new MetroFramework.Controls.MetroCheckBox();
-            this.force3DOFCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.aggressiveKeyframeResend = new MetroFramework.Controls.MetroCheckBox();
-            this.trackingFrameOffsetTextBox = new MetroFramework.Controls.MetroTextBox();
-            this.connectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
-            this.disconnectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
-            this.numericUpDown4 = new System.Windows.Forms.NumericUpDown();
-            this.numericUpDown5 = new System.Windows.Forms.NumericUpDown();
-            this.numericUpDown6 = new System.Windows.Forms.NumericUpDown();
-            this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
-            this.numericUpDown2 = new System.Windows.Forms.NumericUpDown();
-            this.numericUpDown3 = new System.Windows.Forms.NumericUpDown();
-            this.controllerPoseOffset = new MetroFramework.Controls.MetroTextBox();
-            this.debugLogCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.debugCaptureOutputCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.metroTabControl1.SuspendLayout();
             this.serverTab.SuspendLayout();
             this.findingPanel.SuspendLayout();
@@ -265,10 +268,35 @@
             this.connectedPanel.SuspendLayout();
             this.tableLayoutPanel8.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.statDataGridView)).BeginInit();
+            this.presetsTab.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            this.flowLayoutPanel44.SuspendLayout();
+            this.flowLayoutPanel42.SuspendLayout();
+            this.otherTab.SuspendLayout();
+            this.tableLayoutPanel11.SuspendLayout();
+            this.flowLayoutPanel26.SuspendLayout();
+            this.flowLayoutPanel35.SuspendLayout();
+            this.flowLayoutPanel36.SuspendLayout();
+            this.flowLayoutPanel15.SuspendLayout();
+            this.flowLayoutPanel17.SuspendLayout();
+            this.flowLayoutPanel24.SuspendLayout();
+            this.flowLayoutPanel25.SuspendLayout();
+            this.tableLayoutPanel3.SuspendLayout();
+            this.flowLayoutPanel43.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown4)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown5)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown6)).BeginInit();
+            this.flowLayoutPanel37.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).BeginInit();
+            this.flowLayoutPanel38.SuspendLayout();
+            this.flowLayoutPanel16.SuspendLayout();
             this.videoTab.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel39.SuspendLayout();
             this.flowLayoutPanel40.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.sharpeningBox)).BeginInit();
             this.flowLayoutPanel2.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel3.SuspendLayout();
@@ -283,32 +311,19 @@
             this.flowLayoutPanel27.SuspendLayout();
             this.flowLayoutPanel32.SuspendLayout();
             this.flowLayoutPanel28.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.saturationBox)).BeginInit();
             this.flowLayoutPanel30.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.contrastBox)).BeginInit();
             this.flowLayoutPanel33.SuspendLayout();
             this.flowLayoutPanel29.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.brightnessBox)).BeginInit();
             this.flowLayoutPanel31.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.gammaBox)).BeginInit();
             this.flowLayoutPanel34.SuspendLayout();
             this.soundTab.SuspendLayout();
             this.tableLayoutPanel9.SuspendLayout();
             this.flowLayoutPanel13.SuspendLayout();
             this.flowLayoutPanel14.SuspendLayout();
-            this.otherTab.SuspendLayout();
-            this.tableLayoutPanel11.SuspendLayout();
-            this.flowLayoutPanel26.SuspendLayout();
-            this.flowLayoutPanel35.SuspendLayout();
-            this.flowLayoutPanel36.SuspendLayout();
-            this.flowLayoutPanel15.SuspendLayout();
-            this.flowLayoutPanel17.SuspendLayout();
-            this.flowLayoutPanel24.SuspendLayout();
-            this.flowLayoutPanel25.SuspendLayout();
-            this.tableLayoutPanel3.SuspendLayout();
-            this.flowLayoutPanel43.SuspendLayout();
-            this.flowLayoutPanel37.SuspendLayout();
-            this.flowLayoutPanel38.SuspendLayout();
-            this.flowLayoutPanel16.SuspendLayout();
-            this.presetsTab.SuspendLayout();
-            this.tableLayoutPanel2.SuspendLayout();
-            this.flowLayoutPanel42.SuspendLayout();
             this.debugTab.SuspendLayout();
             this.tableLayoutPanel14.SuspendLayout();
             this.flowLayoutPanel18.SuspendLayout();
@@ -321,17 +336,6 @@
             this.flowLayoutPanel23.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.resolutionBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.sharpeningBox)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.saturationBox)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.contrastBox)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.brightnessBox)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.gammaBox)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown4)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown5)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown6)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).BeginInit();
             this.SuspendLayout();
             // 
             // sendClientDebugFlagsButton
@@ -382,7 +386,7 @@
             this.metroTabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.metroTabControl1.Location = new System.Drawing.Point(20, 65);
             this.metroTabControl1.Name = "metroTabControl1";
-            this.metroTabControl1.SelectedIndex = 3;
+            this.metroTabControl1.SelectedIndex = 0;
             this.metroTabControl1.Size = new System.Drawing.Size(663, 456);
             this.metroTabControl1.TabIndex = 8;
             // 
@@ -797,6 +801,806 @@
             this.autoConnectCheckBox.UseVisualStyleBackColor = true;
             this.autoConnectCheckBox.CheckedChanged += new System.EventHandler(this.autoConnectCheckBox_CheckedChanged);
             // 
+            // presetsTab
+            // 
+            this.presetsTab.Controls.Add(this.tableLayoutPanel2);
+            this.presetsTab.HorizontalScrollbarBarColor = true;
+            this.presetsTab.HorizontalScrollbarSize = 0;
+            this.presetsTab.Location = new System.Drawing.Point(4, 35);
+            this.presetsTab.Name = "presetsTab";
+            this.presetsTab.Size = new System.Drawing.Size(655, 417);
+            this.presetsTab.TabIndex = 9;
+            this.presetsTab.Text = "Presets";
+            this.presetsTab.VerticalScrollbarBarColor = true;
+            this.presetsTab.VerticalScrollbarSize = 0;
+            // 
+            // tableLayoutPanel2
+            // 
+            this.tableLayoutPanel2.BackColor = System.Drawing.SystemColors.Window;
+            this.tableLayoutPanel2.ColumnCount = 2;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel44, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.metroLabel38, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel42, 1, 0);
+            this.tableLayoutPanel2.Controls.Add(this.metroLabel42, 0, 1);
+            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            this.tableLayoutPanel2.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
+            this.tableLayoutPanel2.RowCount = 3;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(655, 417);
+            this.tableLayoutPanel2.TabIndex = 9;
+            // 
+            // flowLayoutPanel44
+            // 
+            this.flowLayoutPanel44.AutoSize = true;
+            this.flowLayoutPanel44.Controls.Add(this.fixBoneworksControllersButton);
+            this.flowLayoutPanel44.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel44.Location = new System.Drawing.Point(103, 50);
+            this.flowLayoutPanel44.Name = "flowLayoutPanel44";
+            this.flowLayoutPanel44.Size = new System.Drawing.Size(549, 31);
+            this.flowLayoutPanel44.TabIndex = 29;
+            // 
+            // fixBoneworksControllersButton
+            // 
+            this.fixBoneworksControllersButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.fixBoneworksControllersButton.Location = new System.Drawing.Point(3, 3);
+            this.fixBoneworksControllersButton.Name = "fixBoneworksControllersButton";
+            this.fixBoneworksControllersButton.Size = new System.Drawing.Size(163, 25);
+            this.fixBoneworksControllersButton.TabIndex = 23;
+            this.fixBoneworksControllersButton.Text = "Boneworks controllers";
+            this.fixBoneworksControllersButton.Click += new System.EventHandler(this.fixBoneworksControllersButton_Click);
+            // 
+            // metroLabel38
+            // 
+            this.metroLabel38.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.metroLabel38.AutoSize = true;
+            this.metroLabel38.Location = new System.Drawing.Point(46, 19);
+            this.metroLabel38.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.metroLabel38.Name = "metroLabel38";
+            this.metroLabel38.Size = new System.Drawing.Size(54, 19);
+            this.metroLabel38.TabIndex = 27;
+            this.metroLabel38.Text = "General";
+            // 
+            // flowLayoutPanel42
+            // 
+            this.flowLayoutPanel42.AutoSize = true;
+            this.flowLayoutPanel42.Controls.Add(this.revertToDefaultButton);
+            this.flowLayoutPanel42.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel42.Location = new System.Drawing.Point(103, 13);
+            this.flowLayoutPanel42.Name = "flowLayoutPanel42";
+            this.flowLayoutPanel42.Size = new System.Drawing.Size(549, 31);
+            this.flowLayoutPanel42.TabIndex = 26;
+            // 
+            // revertToDefaultButton
+            // 
+            this.revertToDefaultButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.revertToDefaultButton.Location = new System.Drawing.Point(3, 3);
+            this.revertToDefaultButton.Name = "revertToDefaultButton";
+            this.revertToDefaultButton.Size = new System.Drawing.Size(163, 25);
+            this.revertToDefaultButton.TabIndex = 23;
+            this.revertToDefaultButton.Text = "Revert all settings to default";
+            this.revertToDefaultButton.Click += new System.EventHandler(this.revertToDefaultButton_Click);
+            // 
+            // metroLabel42
+            // 
+            this.metroLabel42.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.metroLabel42.AutoSize = true;
+            this.metroLabel42.Location = new System.Drawing.Point(63, 56);
+            this.metroLabel42.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.metroLabel42.Name = "metroLabel42";
+            this.metroLabel42.Size = new System.Drawing.Size(37, 19);
+            this.metroLabel42.TabIndex = 28;
+            this.metroLabel42.Text = "Fixes";
+            // 
+            // otherTab
+            // 
+            this.otherTab.Controls.Add(this.tableLayoutPanel11);
+            this.otherTab.HorizontalScrollbarBarColor = true;
+            this.otherTab.HorizontalScrollbarSize = 0;
+            this.otherTab.Location = new System.Drawing.Point(4, 35);
+            this.otherTab.Name = "otherTab";
+            this.otherTab.Size = new System.Drawing.Size(655, 417);
+            this.otherTab.TabIndex = 7;
+            this.otherTab.Text = "Other";
+            this.otherTab.VerticalScrollbar = true;
+            this.otherTab.VerticalScrollbarBarColor = true;
+            this.otherTab.VerticalScrollbarSize = 0;
+            // 
+            // tableLayoutPanel11
+            // 
+            this.tableLayoutPanel11.BackColor = System.Drawing.SystemColors.Window;
+            this.tableLayoutPanel11.ColumnCount = 2;
+            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel26, 1, 0);
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel17, 0, 6);
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel24, 0, 4);
+            this.tableLayoutPanel11.Controls.Add(this.metroLabel26, 0, 3);
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel25, 0, 5);
+            this.tableLayoutPanel11.Controls.Add(this.tableLayoutPanel3, 0, 0);
+            this.tableLayoutPanel11.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel11.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel11.Name = "tableLayoutPanel11";
+            this.tableLayoutPanel11.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
+            this.tableLayoutPanel11.RowCount = 7;
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.Size = new System.Drawing.Size(655, 417);
+            this.tableLayoutPanel11.TabIndex = 37;
+            this.tableLayoutPanel11.Paint += new System.Windows.Forms.PaintEventHandler(this.tableLayoutPanel11_Paint);
+            // 
+            // flowLayoutPanel26
+            // 
+            this.flowLayoutPanel26.AutoSize = true;
+            this.flowLayoutPanel26.Controls.Add(this.onlySteamVRCheckBox);
+            this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel35);
+            this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel36);
+            this.flowLayoutPanel26.Controls.Add(this.force60HzCheckBox);
+            this.flowLayoutPanel26.Controls.Add(this.suppressFrameDropCheckBox);
+            this.flowLayoutPanel26.Controls.Add(this.disableThrottlingCheckBox);
+            this.flowLayoutPanel26.Controls.Add(this.disableController);
+            this.flowLayoutPanel26.Controls.Add(this.force3DOFCheckBox);
+            this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel15);
+            this.flowLayoutPanel26.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel26.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flowLayoutPanel26.Location = new System.Drawing.Point(414, 13);
+            this.flowLayoutPanel26.Name = "flowLayoutPanel26";
+            this.flowLayoutPanel26.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
+            this.flowLayoutPanel26.Size = new System.Drawing.Size(238, 276);
+            this.flowLayoutPanel26.TabIndex = 40;
+            this.flowLayoutPanel26.WrapContents = false;
+            // 
+            // onlySteamVRCheckBox
+            // 
+            this.onlySteamVRCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.onlySteamVRCheckBox.AutoSize = true;
+            this.onlySteamVRCheckBox.Checked = global::ALVR.Properties.Settings.Default.onlySteamVR;
+            this.onlySteamVRCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "onlySteamVR", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.onlySteamVRCheckBox.Location = new System.Drawing.Point(8, 3);
+            this.onlySteamVRCheckBox.Name = "onlySteamVRCheckBox";
+            this.onlySteamVRCheckBox.Size = new System.Drawing.Size(221, 15);
+            this.onlySteamVRCheckBox.TabIndex = 29;
+            this.onlySteamVRCheckBox.Text = "Launch only SteamVR without Steam.";
+            this.onlySteamVRCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // flowLayoutPanel35
+            // 
+            this.flowLayoutPanel35.Controls.Add(this.steamAutoLaunch);
+            this.flowLayoutPanel35.Controls.Add(this.autoLaunchHelp);
+            this.flowLayoutPanel35.Location = new System.Drawing.Point(5, 21);
+            this.flowLayoutPanel35.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel35.Name = "flowLayoutPanel35";
+            this.flowLayoutPanel35.Size = new System.Drawing.Size(233, 21);
+            this.flowLayoutPanel35.TabIndex = 37;
+            // 
+            // steamAutoLaunch
+            // 
+            this.steamAutoLaunch.AutoSize = true;
+            this.steamAutoLaunch.Checked = global::ALVR.Properties.Settings.Default.steamAutolaunch;
+            this.steamAutoLaunch.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "steamAutolaunch", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.steamAutoLaunch.Location = new System.Drawing.Point(3, 3);
+            this.steamAutoLaunch.Name = "steamAutoLaunch";
+            this.steamAutoLaunch.Size = new System.Drawing.Size(206, 15);
+            this.steamAutoLaunch.TabIndex = 36;
+            this.steamAutoLaunch.Text = "Launch SteamVR on HMD connect";
+            this.steamAutoLaunch.UseVisualStyleBackColor = true;
+            // 
+            // autoLaunchHelp
+            // 
+            this.autoLaunchHelp.AutoSize = true;
+            this.autoLaunchHelp.Location = new System.Drawing.Point(215, 0);
+            this.autoLaunchHelp.Name = "autoLaunchHelp";
+            this.autoLaunchHelp.Size = new System.Drawing.Size(15, 19);
+            this.autoLaunchHelp.TabIndex = 37;
+            this.autoLaunchHelp.Text = "?";
+            this.autoLaunchHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // flowLayoutPanel36
+            // 
+            this.flowLayoutPanel36.AutoSize = true;
+            this.flowLayoutPanel36.Controls.Add(this.launchMinimized);
+            this.flowLayoutPanel36.Location = new System.Drawing.Point(5, 42);
+            this.flowLayoutPanel36.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel36.Name = "flowLayoutPanel36";
+            this.flowLayoutPanel36.Size = new System.Drawing.Size(157, 21);
+            this.flowLayoutPanel36.TabIndex = 38;
+            // 
+            // launchMinimized
+            // 
+            this.launchMinimized.AutoSize = true;
+            this.launchMinimized.Checked = global::ALVR.Properties.Settings.Default.launchMinimized;
+            this.launchMinimized.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "launchMinimized", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.launchMinimized.Location = new System.Drawing.Point(3, 3);
+            this.launchMinimized.Name = "launchMinimized";
+            this.launchMinimized.Size = new System.Drawing.Size(151, 15);
+            this.launchMinimized.TabIndex = 0;
+            this.launchMinimized.Text = "Launch ALVR minimized";
+            this.launchMinimized.UseVisualStyleBackColor = true;
+            // 
+            // force60HzCheckBox
+            // 
+            this.force60HzCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.force60HzCheckBox.AutoSize = true;
+            this.force60HzCheckBox.Checked = global::ALVR.Properties.Settings.Default.force60Hz;
+            this.force60HzCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force60Hz", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.force60HzCheckBox.Location = new System.Drawing.Point(8, 66);
+            this.force60HzCheckBox.Name = "force60HzCheckBox";
+            this.force60HzCheckBox.Size = new System.Drawing.Size(81, 15);
+            this.force60HzCheckBox.TabIndex = 31;
+            this.force60HzCheckBox.Text = "Force 60Hz";
+            this.force60HzCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // suppressFrameDropCheckBox
+            // 
+            this.suppressFrameDropCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.suppressFrameDropCheckBox.AutoSize = true;
+            this.suppressFrameDropCheckBox.Checked = global::ALVR.Properties.Settings.Default.suppressFrameDrop;
+            this.suppressFrameDropCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "suppressFrameDrop", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.suppressFrameDropCheckBox.Location = new System.Drawing.Point(8, 87);
+            this.suppressFrameDropCheckBox.Name = "suppressFrameDropCheckBox";
+            this.suppressFrameDropCheckBox.Size = new System.Drawing.Size(132, 15);
+            this.suppressFrameDropCheckBox.TabIndex = 30;
+            this.suppressFrameDropCheckBox.Text = "Suppress frame drop";
+            this.suppressFrameDropCheckBox.UseVisualStyleBackColor = true;
+            this.suppressFrameDropCheckBox.CheckedChanged += new System.EventHandler(this.suppressFrameDropCheckBox_CheckedChanged);
+            // 
+            // disableThrottlingCheckBox
+            // 
+            this.disableThrottlingCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.disableThrottlingCheckBox.AutoSize = true;
+            this.disableThrottlingCheckBox.Checked = global::ALVR.Properties.Settings.Default.disableThrottling;
+            this.disableThrottlingCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableThrottling", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.disableThrottlingCheckBox.Location = new System.Drawing.Point(8, 108);
+            this.disableThrottlingCheckBox.Name = "disableThrottlingCheckBox";
+            this.disableThrottlingCheckBox.Size = new System.Drawing.Size(142, 15);
+            this.disableThrottlingCheckBox.TabIndex = 32;
+            this.disableThrottlingCheckBox.Text = "Disable send throttling";
+            this.disableThrottlingCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // disableController
+            // 
+            this.disableController.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.disableController.AutoSize = true;
+            this.disableController.Checked = global::ALVR.Properties.Settings.Default.disableController;
+            this.disableController.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableController", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.disableController.Location = new System.Drawing.Point(8, 129);
+            this.disableController.Name = "disableController";
+            this.disableController.Size = new System.Drawing.Size(115, 15);
+            this.disableController.TabIndex = 33;
+            this.disableController.Text = "Disable controller";
+            this.disableController.UseVisualStyleBackColor = true;
+            // 
+            // force3DOFCheckBox
+            // 
+            this.force3DOFCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.force3DOFCheckBox.AutoSize = true;
+            this.force3DOFCheckBox.Checked = global::ALVR.Properties.Settings.Default.force3DOF;
+            this.force3DOFCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force3DOF", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.force3DOFCheckBox.Location = new System.Drawing.Point(8, 150);
+            this.force3DOFCheckBox.Name = "force3DOFCheckBox";
+            this.force3DOFCheckBox.Size = new System.Drawing.Size(84, 15);
+            this.force3DOFCheckBox.TabIndex = 34;
+            this.force3DOFCheckBox.Text = "Force 3DOF";
+            this.force3DOFCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // flowLayoutPanel15
+            // 
+            this.flowLayoutPanel15.AutoSize = true;
+            this.flowLayoutPanel15.Controls.Add(this.aggressiveKeyframeResend);
+            this.flowLayoutPanel15.Controls.Add(this.aggressiveKeyframeResendHelp);
+            this.flowLayoutPanel15.Location = new System.Drawing.Point(5, 168);
+            this.flowLayoutPanel15.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel15.Name = "flowLayoutPanel15";
+            this.flowLayoutPanel15.Size = new System.Drawing.Size(194, 21);
+            this.flowLayoutPanel15.TabIndex = 35;
+            // 
+            // aggressiveKeyframeResend
+            // 
+            this.aggressiveKeyframeResend.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.aggressiveKeyframeResend.AutoSize = true;
+            this.aggressiveKeyframeResend.Checked = global::ALVR.Properties.Settings.Default.aggressiveKeyframeResend;
+            this.aggressiveKeyframeResend.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "aggressiveKeyframeResend", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.aggressiveKeyframeResend.Location = new System.Drawing.Point(3, 3);
+            this.aggressiveKeyframeResend.Name = "aggressiveKeyframeResend";
+            this.aggressiveKeyframeResend.Size = new System.Drawing.Size(170, 15);
+            this.aggressiveKeyframeResend.TabIndex = 35;
+            this.aggressiveKeyframeResend.Text = "Aggressive keyframe resend";
+            this.aggressiveKeyframeResend.UseVisualStyleBackColor = true;
+            // 
+            // aggressiveKeyframeResendHelp
+            // 
+            this.aggressiveKeyframeResendHelp.AutoSize = true;
+            this.aggressiveKeyframeResendHelp.BackColor = System.Drawing.SystemColors.ControlDark;
+            this.aggressiveKeyframeResendHelp.FontSize = MetroFramework.MetroLabelSize.Small;
+            this.aggressiveKeyframeResendHelp.Location = new System.Drawing.Point(179, 0);
+            this.aggressiveKeyframeResendHelp.Name = "aggressiveKeyframeResendHelp";
+            this.aggressiveKeyframeResendHelp.Size = new System.Drawing.Size(12, 15);
+            this.aggressiveKeyframeResendHelp.Style = MetroFramework.MetroColorStyle.Blue;
+            this.aggressiveKeyframeResendHelp.TabIndex = 0;
+            this.aggressiveKeyframeResendHelp.Text = "?";
+            this.aggressiveKeyframeResendHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // flowLayoutPanel17
+            // 
+            this.flowLayoutPanel17.AutoSize = true;
+            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel17, 2);
+            this.flowLayoutPanel17.Controls.Add(this.metroLabel29);
+            this.flowLayoutPanel17.Controls.Add(this.trackingFrameOffsetTextBox);
+            this.flowLayoutPanel17.Controls.Add(this.saveTrackingFrameOffsetButton);
+            this.flowLayoutPanel17.Controls.Add(this.metroLabel30);
+            this.flowLayoutPanel17.Location = new System.Drawing.Point(3, 376);
+            this.flowLayoutPanel17.Name = "flowLayoutPanel17";
+            this.flowLayoutPanel17.Size = new System.Drawing.Size(609, 38);
+            this.flowLayoutPanel17.TabIndex = 0;
+            this.flowLayoutPanel17.WrapContents = false;
+            // 
+            // metroLabel29
+            // 
+            this.metroLabel29.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel29.AutoSize = true;
+            this.metroLabel29.Location = new System.Drawing.Point(3, 9);
+            this.metroLabel29.Name = "metroLabel29";
+            this.metroLabel29.Size = new System.Drawing.Size(129, 19);
+            this.metroLabel29.TabIndex = 18;
+            this.metroLabel29.Text = "TrackingFrameOffset";
+            // 
+            // trackingFrameOffsetTextBox
+            // 
+            this.trackingFrameOffsetTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.trackingFrameOffsetTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "trackingFrameOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.trackingFrameOffsetTextBox.Location = new System.Drawing.Point(138, 6);
+            this.trackingFrameOffsetTextBox.Name = "trackingFrameOffsetTextBox";
+            this.trackingFrameOffsetTextBox.Size = new System.Drawing.Size(102, 25);
+            this.trackingFrameOffsetTextBox.TabIndex = 27;
+            this.trackingFrameOffsetTextBox.Text = global::ALVR.Properties.Settings.Default.trackingFrameOffset;
+            // 
+            // saveTrackingFrameOffsetButton
+            // 
+            this.saveTrackingFrameOffsetButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.saveTrackingFrameOffsetButton.Location = new System.Drawing.Point(246, 6);
+            this.saveTrackingFrameOffsetButton.Name = "saveTrackingFrameOffsetButton";
+            this.saveTrackingFrameOffsetButton.Size = new System.Drawing.Size(75, 25);
+            this.saveTrackingFrameOffsetButton.TabIndex = 28;
+            this.saveTrackingFrameOffsetButton.Text = "Save";
+            this.saveTrackingFrameOffsetButton.Click += new System.EventHandler(this.saveTrackingFrameOffsetButton_Click);
+            // 
+            // metroLabel30
+            // 
+            this.metroLabel30.AutoSize = true;
+            this.metroLabel30.Location = new System.Drawing.Point(327, 0);
+            this.metroLabel30.Name = "metroLabel30";
+            this.metroLabel30.Size = new System.Drawing.Size(279, 38);
+            this.metroLabel30.TabIndex = 18;
+            this.metroLabel30.Text = "Try \"-1\" if you exceprience jerky head-tracking.\r\nPut \"0\" on if you have no probl" +
+    "em.";
+            // 
+            // flowLayoutPanel24
+            // 
+            this.flowLayoutPanel24.AutoSize = true;
+            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel24, 2);
+            this.flowLayoutPanel24.Controls.Add(this.metroLabel27);
+            this.flowLayoutPanel24.Controls.Add(this.connectCommandTextBox);
+            this.flowLayoutPanel24.Controls.Add(this.refConnectCommandButton);
+            this.flowLayoutPanel24.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel24.Location = new System.Drawing.Point(0, 311);
+            this.flowLayoutPanel24.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel24.Name = "flowLayoutPanel24";
+            this.flowLayoutPanel24.Size = new System.Drawing.Size(655, 31);
+            this.flowLayoutPanel24.TabIndex = 41;
+            // 
+            // metroLabel27
+            // 
+            this.metroLabel27.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel27.AutoSize = true;
+            this.metroLabel27.Location = new System.Drawing.Point(3, 6);
+            this.metroLabel27.Name = "metroLabel27";
+            this.metroLabel27.Size = new System.Drawing.Size(76, 19);
+            this.metroLabel27.TabIndex = 17;
+            this.metroLabel27.Text = "On connect";
+            // 
+            // connectCommandTextBox
+            // 
+            this.connectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "connectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.connectCommandTextBox.Location = new System.Drawing.Point(85, 3);
+            this.connectCommandTextBox.Name = "connectCommandTextBox";
+            this.connectCommandTextBox.Size = new System.Drawing.Size(351, 25);
+            this.connectCommandTextBox.TabIndex = 23;
+            this.connectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.connectCommand;
+            // 
+            // refConnectCommandButton
+            // 
+            this.refConnectCommandButton.Location = new System.Drawing.Point(442, 3);
+            this.refConnectCommandButton.Name = "refConnectCommandButton";
+            this.refConnectCommandButton.Size = new System.Drawing.Size(52, 25);
+            this.refConnectCommandButton.TabIndex = 24;
+            this.refConnectCommandButton.Text = "...";
+            this.refConnectCommandButton.Click += new System.EventHandler(this.refConnectCommandButton_Click);
+            // 
+            // metroLabel26
+            // 
+            this.metroLabel26.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel26.AutoSize = true;
+            this.metroLabel26.FontWeight = MetroFramework.MetroLabelWeight.Regular;
+            this.metroLabel26.Location = new System.Drawing.Point(3, 292);
+            this.metroLabel26.Name = "metroLabel26";
+            this.metroLabel26.Size = new System.Drawing.Size(101, 19);
+            this.metroLabel26.TabIndex = 3;
+            this.metroLabel26.Text = "Run command:";
+            // 
+            // flowLayoutPanel25
+            // 
+            this.flowLayoutPanel25.AutoSize = true;
+            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel25, 2);
+            this.flowLayoutPanel25.Controls.Add(this.metroLabel28);
+            this.flowLayoutPanel25.Controls.Add(this.disconnectCommandTextBox);
+            this.flowLayoutPanel25.Controls.Add(this.refDisconnectCommandButton);
+            this.flowLayoutPanel25.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel25.Location = new System.Drawing.Point(0, 342);
+            this.flowLayoutPanel25.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel25.Name = "flowLayoutPanel25";
+            this.flowLayoutPanel25.Size = new System.Drawing.Size(655, 31);
+            this.flowLayoutPanel25.TabIndex = 42;
+            // 
+            // metroLabel28
+            // 
+            this.metroLabel28.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel28.AutoSize = true;
+            this.metroLabel28.Location = new System.Drawing.Point(3, 6);
+            this.metroLabel28.Name = "metroLabel28";
+            this.metroLabel28.Size = new System.Drawing.Size(92, 19);
+            this.metroLabel28.TabIndex = 17;
+            this.metroLabel28.Text = "On disconnect";
+            // 
+            // disconnectCommandTextBox
+            // 
+            this.disconnectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "disconnectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.disconnectCommandTextBox.Location = new System.Drawing.Point(101, 3);
+            this.disconnectCommandTextBox.Name = "disconnectCommandTextBox";
+            this.disconnectCommandTextBox.Size = new System.Drawing.Size(383, 25);
+            this.disconnectCommandTextBox.TabIndex = 25;
+            this.disconnectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.disconnectCommand;
+            // 
+            // refDisconnectCommandButton
+            // 
+            this.refDisconnectCommandButton.Location = new System.Drawing.Point(490, 3);
+            this.refDisconnectCommandButton.Name = "refDisconnectCommandButton";
+            this.refDisconnectCommandButton.Size = new System.Drawing.Size(52, 25);
+            this.refDisconnectCommandButton.TabIndex = 26;
+            this.refDisconnectCommandButton.Text = "...";
+            this.refDisconnectCommandButton.Click += new System.EventHandler(this.refDisconnectCommandButton_Click);
+            // 
+            // tableLayoutPanel3
+            // 
+            this.tableLayoutPanel3.AutoSize = true;
+            this.tableLayoutPanel3.ColumnCount = 1;
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel43, 0, 4);
+            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel37, 0, 3);
+            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel38, 0, 2);
+            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel16, 0, 1);
+            this.tableLayoutPanel3.Controls.Add(this.metroLabel41, 0, 0);
+            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 13);
+            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            this.tableLayoutPanel3.RowCount = 6;
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(405, 276);
+            this.tableLayoutPanel3.TabIndex = 44;
+            // 
+            // flowLayoutPanel43
+            // 
+            this.flowLayoutPanel43.AutoSize = true;
+            this.flowLayoutPanel43.Controls.Add(this.metroLabel40);
+            this.flowLayoutPanel43.Controls.Add(this.controllerRotationOffsetHelp);
+            this.flowLayoutPanel43.Controls.Add(this.numericUpDown4);
+            this.flowLayoutPanel43.Controls.Add(this.numericUpDown5);
+            this.flowLayoutPanel43.Controls.Add(this.numericUpDown6);
+            this.flowLayoutPanel43.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel43.Location = new System.Drawing.Point(3, 132);
+            this.flowLayoutPanel43.Name = "flowLayoutPanel43";
+            this.flowLayoutPanel43.Size = new System.Drawing.Size(399, 26);
+            this.flowLayoutPanel43.TabIndex = 39;
+            // 
+            // metroLabel40
+            // 
+            this.metroLabel40.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel40.AutoSize = true;
+            this.metroLabel40.Location = new System.Drawing.Point(3, 3);
+            this.metroLabel40.Name = "metroLabel40";
+            this.metroLabel40.Size = new System.Drawing.Size(210, 19);
+            this.metroLabel40.TabIndex = 0;
+            this.metroLabel40.Text = "Left rotation offset (pitch, yaw, roll)";
+            // 
+            // controllerRotationOffsetHelp
+            // 
+            this.controllerRotationOffsetHelp.AutoSize = true;
+            this.controllerRotationOffsetHelp.Location = new System.Drawing.Point(219, 0);
+            this.controllerRotationOffsetHelp.Name = "controllerRotationOffsetHelp";
+            this.controllerRotationOffsetHelp.Size = new System.Drawing.Size(15, 19);
+            this.controllerRotationOffsetHelp.TabIndex = 52;
+            this.controllerRotationOffsetHelp.Text = "?";
+            this.controllerRotationOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // numericUpDown4
+            // 
+            this.numericUpDown4.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPitchOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown4.Location = new System.Drawing.Point(240, 3);
+            this.numericUpDown4.Maximum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            0});
+            this.numericUpDown4.Minimum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            -2147483648});
+            this.numericUpDown4.Name = "numericUpDown4";
+            this.numericUpDown4.Size = new System.Drawing.Size(45, 20);
+            this.numericUpDown4.TabIndex = 54;
+            this.numericUpDown4.Value = global::ALVR.Properties.Settings.Default.leftControllerPitchOffset;
+            // 
+            // numericUpDown5
+            // 
+            this.numericUpDown5.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerYawOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown5.Location = new System.Drawing.Point(291, 3);
+            this.numericUpDown5.Maximum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            0});
+            this.numericUpDown5.Minimum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            -2147483648});
+            this.numericUpDown5.Name = "numericUpDown5";
+            this.numericUpDown5.Size = new System.Drawing.Size(45, 20);
+            this.numericUpDown5.TabIndex = 55;
+            this.numericUpDown5.Value = global::ALVR.Properties.Settings.Default.leftControllerYawOffset;
+            // 
+            // numericUpDown6
+            // 
+            this.numericUpDown6.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerRollOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown6.Location = new System.Drawing.Point(342, 3);
+            this.numericUpDown6.Maximum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            0});
+            this.numericUpDown6.Minimum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            -2147483648});
+            this.numericUpDown6.Name = "numericUpDown6";
+            this.numericUpDown6.Size = new System.Drawing.Size(45, 20);
+            this.numericUpDown6.TabIndex = 56;
+            this.numericUpDown6.Value = global::ALVR.Properties.Settings.Default.leftControllerRollOffset;
+            // 
+            // flowLayoutPanel37
+            // 
+            this.flowLayoutPanel37.AutoSize = true;
+            this.flowLayoutPanel37.Controls.Add(this.metroLabel39);
+            this.flowLayoutPanel37.Controls.Add(this.controllerPositionOffsetHelp);
+            this.flowLayoutPanel37.Controls.Add(this.numericUpDown1);
+            this.flowLayoutPanel37.Controls.Add(this.numericUpDown2);
+            this.flowLayoutPanel37.Controls.Add(this.numericUpDown3);
+            this.flowLayoutPanel37.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel37.Location = new System.Drawing.Point(3, 100);
+            this.flowLayoutPanel37.Name = "flowLayoutPanel37";
+            this.flowLayoutPanel37.Size = new System.Drawing.Size(399, 26);
+            this.flowLayoutPanel37.TabIndex = 38;
+            // 
+            // metroLabel39
+            // 
+            this.metroLabel39.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel39.AutoSize = true;
+            this.metroLabel39.Location = new System.Drawing.Point(3, 3);
+            this.metroLabel39.Name = "metroLabel39";
+            this.metroLabel39.Size = new System.Drawing.Size(159, 19);
+            this.metroLabel39.TabIndex = 0;
+            this.metroLabel39.Text = "Left position offset (x, y, z)";
+            // 
+            // controllerPositionOffsetHelp
+            // 
+            this.controllerPositionOffsetHelp.AutoSize = true;
+            this.controllerPositionOffsetHelp.Location = new System.Drawing.Point(168, 0);
+            this.controllerPositionOffsetHelp.Name = "controllerPositionOffsetHelp";
+            this.controllerPositionOffsetHelp.Size = new System.Drawing.Size(15, 19);
+            this.controllerPositionOffsetHelp.TabIndex = 52;
+            this.controllerPositionOffsetHelp.Text = "?";
+            this.controllerPositionOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // numericUpDown1
+            // 
+            this.numericUpDown1.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetX", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown1.DecimalPlaces = 3;
+            this.numericUpDown1.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            196608});
+            this.numericUpDown1.Location = new System.Drawing.Point(189, 3);
+            this.numericUpDown1.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.numericUpDown1.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.numericUpDown1.Name = "numericUpDown1";
+            this.numericUpDown1.Size = new System.Drawing.Size(55, 20);
+            this.numericUpDown1.TabIndex = 53;
+            this.numericUpDown1.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetX;
+            // 
+            // numericUpDown2
+            // 
+            this.numericUpDown2.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetY", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown2.DecimalPlaces = 3;
+            this.numericUpDown2.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            196608});
+            this.numericUpDown2.Location = new System.Drawing.Point(250, 3);
+            this.numericUpDown2.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.numericUpDown2.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.numericUpDown2.Name = "numericUpDown2";
+            this.numericUpDown2.Size = new System.Drawing.Size(55, 20);
+            this.numericUpDown2.TabIndex = 54;
+            this.numericUpDown2.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetY;
+            // 
+            // numericUpDown3
+            // 
+            this.numericUpDown3.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetZ", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown3.DecimalPlaces = 3;
+            this.numericUpDown3.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            196608});
+            this.numericUpDown3.Location = new System.Drawing.Point(311, 3);
+            this.numericUpDown3.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.numericUpDown3.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.numericUpDown3.Name = "numericUpDown3";
+            this.numericUpDown3.Size = new System.Drawing.Size(55, 20);
+            this.numericUpDown3.TabIndex = 55;
+            this.numericUpDown3.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetZ;
+            // 
+            // flowLayoutPanel38
+            // 
+            this.flowLayoutPanel38.AutoSize = true;
+            this.flowLayoutPanel38.Controls.Add(this.metroLabel36);
+            this.flowLayoutPanel38.Controls.Add(this.handTrackingModeHelp);
+            this.flowLayoutPanel38.Controls.Add(this.controllerModeComboBox);
+            this.flowLayoutPanel38.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel38.Location = new System.Drawing.Point(3, 59);
+            this.flowLayoutPanel38.Name = "flowLayoutPanel38";
+            this.flowLayoutPanel38.Size = new System.Drawing.Size(399, 35);
+            this.flowLayoutPanel38.TabIndex = 0;
+            // 
+            // metroLabel36
+            // 
+            this.metroLabel36.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel36.AutoSize = true;
+            this.metroLabel36.Location = new System.Drawing.Point(3, 8);
+            this.metroLabel36.Name = "metroLabel36";
+            this.metroLabel36.Size = new System.Drawing.Size(129, 19);
+            this.metroLabel36.TabIndex = 0;
+            this.metroLabel36.Text = "Hand tracking mode";
+            // 
+            // handTrackingModeHelp
+            // 
+            this.handTrackingModeHelp.AutoSize = true;
+            this.handTrackingModeHelp.Location = new System.Drawing.Point(138, 0);
+            this.handTrackingModeHelp.Name = "handTrackingModeHelp";
+            this.handTrackingModeHelp.Size = new System.Drawing.Size(15, 19);
+            this.handTrackingModeHelp.TabIndex = 53;
+            this.handTrackingModeHelp.Text = "?";
+            this.handTrackingModeHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // controllerModeComboBox
+            // 
+            this.controllerModeComboBox.FormattingEnabled = true;
+            this.controllerModeComboBox.ItemHeight = 23;
+            this.controllerModeComboBox.Location = new System.Drawing.Point(159, 3);
+            this.controllerModeComboBox.Name = "controllerModeComboBox";
+            this.controllerModeComboBox.Size = new System.Drawing.Size(232, 29);
+            this.controllerModeComboBox.TabIndex = 1;
+            this.controllerModeComboBox.SelectedIndexChanged += new System.EventHandler(this.metroComboBox1_SelectedIndexChanged);
+            // 
+            // flowLayoutPanel16
+            // 
+            this.flowLayoutPanel16.AutoSize = true;
+            this.flowLayoutPanel16.Controls.Add(this.metroLabel12);
+            this.flowLayoutPanel16.Controls.Add(this.controllerPoseOffset);
+            this.flowLayoutPanel16.Controls.Add(this.metroButton1);
+            this.flowLayoutPanel16.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel16.Location = new System.Drawing.Point(3, 22);
+            this.flowLayoutPanel16.Name = "flowLayoutPanel16";
+            this.flowLayoutPanel16.Size = new System.Drawing.Size(399, 31);
+            this.flowLayoutPanel16.TabIndex = 37;
+            this.flowLayoutPanel16.WrapContents = false;
+            // 
+            // metroLabel12
+            // 
+            this.metroLabel12.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel12.AutoSize = true;
+            this.metroLabel12.Location = new System.Drawing.Point(3, 6);
+            this.metroLabel12.Name = "metroLabel12";
+            this.metroLabel12.Size = new System.Drawing.Size(102, 19);
+            this.metroLabel12.TabIndex = 20;
+            this.metroLabel12.Text = "Pose time offset";
+            this.metroLabel12.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // controllerPoseOffset
+            // 
+            this.controllerPoseOffset.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.controllerPoseOffset.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "controllerPoseOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.controllerPoseOffset.Location = new System.Drawing.Point(111, 6);
+            this.controllerPoseOffset.Name = "controllerPoseOffset";
+            this.controllerPoseOffset.Size = new System.Drawing.Size(52, 19);
+            this.controllerPoseOffset.TabIndex = 21;
+            this.controllerPoseOffset.Text = global::ALVR.Properties.Settings.Default.controllerPoseOffset;
+            this.controllerPoseOffset.Click += new System.EventHandler(this.controllerPoseOffset_Click);
+            // 
+            // metroButton1
+            // 
+            this.metroButton1.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroButton1.Location = new System.Drawing.Point(169, 3);
+            this.metroButton1.Name = "metroButton1";
+            this.metroButton1.Size = new System.Drawing.Size(75, 25);
+            this.metroButton1.TabIndex = 22;
+            this.metroButton1.Text = "Save";
+            this.metroButton1.Click += new System.EventHandler(this.metroButton1_Click);
+            // 
+            // metroLabel41
+            // 
+            this.metroLabel41.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel41.AutoSize = true;
+            this.metroLabel41.FontWeight = MetroFramework.MetroLabelWeight.Regular;
+            this.metroLabel41.Location = new System.Drawing.Point(3, 0);
+            this.metroLabel41.Name = "metroLabel41";
+            this.metroLabel41.Size = new System.Drawing.Size(125, 19);
+            this.metroLabel41.TabIndex = 40;
+            this.metroLabel41.Text = "Controller settings:";
+            this.metroLabel41.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
             // videoTab
             // 
             this.videoTab.BackColor = System.Drawing.SystemColors.Window;
@@ -912,6 +1716,31 @@
             this.metroLabel37.TabIndex = 45;
             this.metroLabel37.Text = "Sharpening";
             // 
+            // sharpeningBox
+            // 
+            this.sharpeningBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "sharpening", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.sharpeningBox.DecimalPlaces = 2;
+            this.sharpeningBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.sharpeningBox.Location = new System.Drawing.Point(82, 3);
+            this.sharpeningBox.Maximum = new decimal(new int[] {
+            500,
+            0,
+            0,
+            131072});
+            this.sharpeningBox.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.sharpeningBox.Name = "sharpeningBox";
+            this.sharpeningBox.Size = new System.Drawing.Size(44, 20);
+            this.sharpeningBox.TabIndex = 44;
+            this.sharpeningBox.Value = global::ALVR.Properties.Settings.Default.sharpening;
+            // 
             // flowLayoutPanel41
             // 
             this.flowLayoutPanel41.Location = new System.Drawing.Point(128, 0);
@@ -977,6 +1806,20 @@
             this.flowLayoutPanel1.Size = new System.Drawing.Size(136, 21);
             this.flowLayoutPanel1.TabIndex = 38;
             // 
+            // forceNV12
+            // 
+            this.forceNV12.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.forceNV12.AutoSize = true;
+            this.forceNV12.Checked = global::ALVR.Properties.Settings.Default.nv12;
+            this.forceNV12.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "nv12", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.forceNV12.Location = new System.Drawing.Point(3, 3);
+            this.forceNV12.Margin = new System.Windows.Forms.Padding(3, 3, 0, 3);
+            this.forceNV12.Name = "forceNV12";
+            this.forceNV12.Size = new System.Drawing.Size(115, 15);
+            this.forceNV12.TabIndex = 35;
+            this.forceNV12.Text = "use custom NV12";
+            this.forceNV12.UseVisualStyleBackColor = true;
+            // 
             // nv12Tooltip
             // 
             this.nv12Tooltip.AutoSize = true;
@@ -1032,6 +1875,22 @@
             this.bitrateLabel.Size = new System.Drawing.Size(60, 19);
             this.bitrateLabel.TabIndex = 5;
             this.bitrateLabel.Text = "30Mbps";
+            // 
+            // bitrateTrackBar
+            // 
+            this.bitrateTrackBar.BackColor = System.Drawing.Color.Transparent;
+            this.bitrateTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "bitrate", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.bitrateTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.bitrateTrackBar.Location = new System.Drawing.Point(233, 73);
+            this.bitrateTrackBar.Maximum = 250;
+            this.bitrateTrackBar.Minimum = 1;
+            this.bitrateTrackBar.Name = "bitrateTrackBar";
+            this.bitrateTrackBar.Size = new System.Drawing.Size(269, 25);
+            this.bitrateTrackBar.TabIndex = 2;
+            this.bitrateTrackBar.Text = "metroTrackBar1";
+            this.bitrateTrackBar.Value = global::ALVR.Properties.Settings.Default.bitrate;
+            this.bitrateTrackBar.ValueChanged += new System.EventHandler(this.bitrateTrackBar_ValueChanged);
+            this.bitrateTrackBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.bitrateTrackBar_Scroll);
             // 
             // flowLayoutPanel5
             // 
@@ -1180,6 +2039,33 @@
             this.bufferHelp.Text = "?";
             this.bufferHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
+            // enableColorCorrectionCheckBox
+            // 
+            this.enableColorCorrectionCheckBox.AutoSize = true;
+            this.enableColorCorrectionCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableColorCorrection;
+            this.enableColorCorrectionCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableColorCorrection", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.enableColorCorrectionCheckBox.Location = new System.Drawing.Point(233, 295);
+            this.enableColorCorrectionCheckBox.Name = "enableColorCorrectionCheckBox";
+            this.enableColorCorrectionCheckBox.Size = new System.Drawing.Size(58, 15);
+            this.enableColorCorrectionCheckBox.TabIndex = 40;
+            this.enableColorCorrectionCheckBox.Text = "Enable";
+            this.enableColorCorrectionCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // bufferTrackBar
+            // 
+            this.bufferTrackBar.BackColor = System.Drawing.Color.Transparent;
+            this.bufferTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "bufferOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.bufferTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.bufferTrackBar.Location = new System.Drawing.Point(233, 160);
+            this.bufferTrackBar.Minimum = -100;
+            this.bufferTrackBar.Name = "bufferTrackBar";
+            this.bufferTrackBar.Size = new System.Drawing.Size(269, 20);
+            this.bufferTrackBar.TabIndex = 2;
+            this.bufferTrackBar.Text = "metroTrackBar1";
+            this.bufferTrackBar.Value = global::ALVR.Properties.Settings.Default.bufferOffset;
+            this.bufferTrackBar.ValueChanged += new System.EventHandler(this.bufferTrackBar_ValueChanged);
+            this.bufferTrackBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.bufferTrackBar_Scroll);
+            // 
             // flowLayoutPanel9
             // 
             this.flowLayoutPanel9.Anchor = System.Windows.Forms.AnchorStyles.Right;
@@ -1278,6 +2164,23 @@
             this.foveationStrengthLabel.Text = "2";
             this.foveationStrengthLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
+            // foveationStrengthTrackBar
+            // 
+            this.foveationStrengthTrackBar.BackColor = System.Drawing.Color.Transparent;
+            this.foveationStrengthTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "foveationStrength", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.foveationStrengthTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.foveationStrengthTrackBar.LargeChange = 100;
+            this.foveationStrengthTrackBar.Location = new System.Drawing.Point(233, 240);
+            this.foveationStrengthTrackBar.Maximum = 500;
+            this.foveationStrengthTrackBar.MaximumSize = new System.Drawing.Size(0, 14);
+            this.foveationStrengthTrackBar.Name = "foveationStrengthTrackBar";
+            this.foveationStrengthTrackBar.Size = new System.Drawing.Size(269, 10);
+            this.foveationStrengthTrackBar.SmallChange = 10;
+            this.foveationStrengthTrackBar.TabIndex = 30;
+            this.foveationStrengthTrackBar.Text = "metroTrackBar1";
+            this.foveationStrengthTrackBar.Value = global::ALVR.Properties.Settings.Default.foveationStrength;
+            this.foveationStrengthTrackBar.ValueChanged += new System.EventHandler(this.FoveationStrengthTrackBar_ValueChanged);
+            // 
             // flowLayoutPanel11
             // 
             this.flowLayoutPanel11.AutoSize = true;
@@ -1311,6 +2214,23 @@
             this.ffrVerticalOffsetHelp.TabIndex = 32;
             this.ffrVerticalOffsetHelp.Text = "?";
             this.ffrVerticalOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // foveationVerticalOffsetTrackBar
+            // 
+            this.foveationVerticalOffsetTrackBar.BackColor = System.Drawing.Color.Transparent;
+            this.foveationVerticalOffsetTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "foveationVerticalOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.foveationVerticalOffsetTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.foveationVerticalOffsetTrackBar.LargeChange = 2;
+            this.foveationVerticalOffsetTrackBar.Location = new System.Drawing.Point(233, 275);
+            this.foveationVerticalOffsetTrackBar.Maximum = 10;
+            this.foveationVerticalOffsetTrackBar.Minimum = -10;
+            this.foveationVerticalOffsetTrackBar.MouseWheelBarPartitions = 1;
+            this.foveationVerticalOffsetTrackBar.Name = "foveationVerticalOffsetTrackBar";
+            this.foveationVerticalOffsetTrackBar.Size = new System.Drawing.Size(269, 14);
+            this.foveationVerticalOffsetTrackBar.TabIndex = 34;
+            this.foveationVerticalOffsetTrackBar.Text = "metroTrackBar1";
+            this.foveationVerticalOffsetTrackBar.Value = global::ALVR.Properties.Settings.Default.foveationVerticalOffset;
+            this.foveationVerticalOffsetTrackBar.ValueChanged += new System.EventHandler(this.FoveationVerticalOffsetTrackBar_ValueChanged);
             // 
             // foveationVerticalOffsetLabel
             // 
@@ -1477,6 +2397,31 @@
             this.metroLabel33.TabIndex = 47;
             this.metroLabel33.Text = "Saturation";
             // 
+            // saturationBox
+            // 
+            this.saturationBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "saturation", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.saturationBox.DecimalPlaces = 2;
+            this.saturationBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.saturationBox.Location = new System.Drawing.Point(75, 3);
+            this.saturationBox.Maximum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.saturationBox.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            -2147483648});
+            this.saturationBox.Name = "saturationBox";
+            this.saturationBox.Size = new System.Drawing.Size(46, 20);
+            this.saturationBox.TabIndex = 48;
+            this.saturationBox.Value = global::ALVR.Properties.Settings.Default.saturation;
+            // 
             // flowLayoutPanel30
             // 
             this.flowLayoutPanel30.Controls.Add(this.metroLabel25);
@@ -1497,6 +2442,31 @@
             this.metroLabel25.Size = new System.Drawing.Size(58, 19);
             this.metroLabel25.TabIndex = 43;
             this.metroLabel25.Text = "Contrast";
+            // 
+            // contrastBox
+            // 
+            this.contrastBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "contrast", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.contrastBox.DecimalPlaces = 2;
+            this.contrastBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.contrastBox.Location = new System.Drawing.Point(65, 3);
+            this.contrastBox.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.contrastBox.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.contrastBox.Name = "contrastBox";
+            this.contrastBox.Size = new System.Drawing.Size(45, 20);
+            this.contrastBox.TabIndex = 46;
+            this.contrastBox.Value = global::ALVR.Properties.Settings.Default.contrast;
             // 
             // flowLayoutPanel33
             // 
@@ -1533,6 +2503,31 @@
             this.metroLabel32.TabIndex = 45;
             this.metroLabel32.Text = "Brightness";
             // 
+            // brightnessBox
+            // 
+            this.brightnessBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "brightness", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.brightnessBox.DecimalPlaces = 2;
+            this.brightnessBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.brightnessBox.Location = new System.Drawing.Point(75, 3);
+            this.brightnessBox.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.brightnessBox.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.brightnessBox.Name = "brightnessBox";
+            this.brightnessBox.Size = new System.Drawing.Size(44, 20);
+            this.brightnessBox.TabIndex = 44;
+            this.brightnessBox.Value = global::ALVR.Properties.Settings.Default.brightness;
+            // 
             // flowLayoutPanel31
             // 
             this.flowLayoutPanel31.Controls.Add(this.metroLabel24);
@@ -1553,6 +2548,26 @@
             this.metroLabel24.Size = new System.Drawing.Size(56, 19);
             this.metroLabel24.TabIndex = 41;
             this.metroLabel24.Text = "Gamma";
+            // 
+            // gammaBox
+            // 
+            this.gammaBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "gamma", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.gammaBox.DecimalPlaces = 2;
+            this.gammaBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.gammaBox.Location = new System.Drawing.Point(63, 3);
+            this.gammaBox.Maximum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.gammaBox.Name = "gammaBox";
+            this.gammaBox.Size = new System.Drawing.Size(45, 20);
+            this.gammaBox.TabIndex = 42;
+            this.gammaBox.Value = global::ALVR.Properties.Settings.Default.gamma;
             // 
             // flowLayoutPanel34
             // 
@@ -1633,6 +2648,20 @@
             this.flowLayoutPanel13.TabIndex = 0;
             this.flowLayoutPanel13.WrapContents = false;
             // 
+            // soundCheckBox
+            // 
+            this.soundCheckBox.AutoSize = true;
+            this.soundCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableSound;
+            this.soundCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.soundCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableSound", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.soundCheckBox.Location = new System.Drawing.Point(3, 3);
+            this.soundCheckBox.Name = "soundCheckBox";
+            this.soundCheckBox.Size = new System.Drawing.Size(92, 15);
+            this.soundCheckBox.TabIndex = 2;
+            this.soundCheckBox.Text = "Steam sound";
+            this.soundCheckBox.UseVisualStyleBackColor = true;
+            this.soundCheckBox.CheckedChanged += new System.EventHandler(this.soundCheckBox_CheckedChanged);
+            // 
             // noSoundDeviceLabel
             // 
             this.noSoundDeviceLabel.AutoSize = true;
@@ -1652,6 +2681,20 @@
             this.soundDeviceComboBox.Name = "soundDeviceComboBox";
             this.soundDeviceComboBox.Size = new System.Drawing.Size(469, 29);
             this.soundDeviceComboBox.TabIndex = 3;
+            // 
+            // streamMic
+            // 
+            this.streamMic.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.streamMic.AutoSize = true;
+            this.streamMic.Checked = global::ALVR.Properties.Settings.Default.streamMic;
+            this.streamMic.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "streamMic", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.streamMic.Location = new System.Drawing.Point(3, 73);
+            this.streamMic.Name = "streamMic";
+            this.streamMic.Size = new System.Drawing.Size(162, 15);
+            this.streamMic.TabIndex = 5;
+            this.streamMic.Text = "Stream Quest Microphone";
+            this.streamMic.UseVisualStyleBackColor = true;
+            this.streamMic.CheckedChanged += new System.EventHandler(this.metroCheckBox4_CheckedChanged);
             // 
             // flowLayoutPanel14
             // 
@@ -1687,484 +2730,21 @@
             this.metroLink1.Text = " https://www.vb-audio.com/Cable/";
             this.metroLink1.Click += new System.EventHandler(this.metroLink1_Click);
             // 
-            // otherTab
-            // 
-            this.otherTab.Controls.Add(this.tableLayoutPanel11);
-            this.otherTab.HorizontalScrollbarBarColor = true;
-            this.otherTab.HorizontalScrollbarSize = 0;
-            this.otherTab.Location = new System.Drawing.Point(4, 35);
-            this.otherTab.Name = "otherTab";
-            this.otherTab.Size = new System.Drawing.Size(655, 417);
-            this.otherTab.TabIndex = 7;
-            this.otherTab.Text = "Other";
-            this.otherTab.VerticalScrollbar = true;
-            this.otherTab.VerticalScrollbarBarColor = true;
-            this.otherTab.VerticalScrollbarSize = 0;
-            // 
-            // tableLayoutPanel11
-            // 
-            this.tableLayoutPanel11.BackColor = System.Drawing.SystemColors.Window;
-            this.tableLayoutPanel11.ColumnCount = 2;
-            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel26, 1, 0);
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel17, 0, 6);
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel24, 0, 4);
-            this.tableLayoutPanel11.Controls.Add(this.metroLabel26, 0, 3);
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel25, 0, 5);
-            this.tableLayoutPanel11.Controls.Add(this.tableLayoutPanel3, 0, 0);
-            this.tableLayoutPanel11.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel11.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel11.Name = "tableLayoutPanel11";
-            this.tableLayoutPanel11.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
-            this.tableLayoutPanel11.RowCount = 7;
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel11.Size = new System.Drawing.Size(655, 417);
-            this.tableLayoutPanel11.TabIndex = 37;
-            this.tableLayoutPanel11.Paint += new System.Windows.Forms.PaintEventHandler(this.tableLayoutPanel11_Paint);
-            // 
-            // flowLayoutPanel26
-            // 
-            this.flowLayoutPanel26.AutoSize = true;
-            this.flowLayoutPanel26.Controls.Add(this.onlySteamVRCheckBox);
-            this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel35);
-            this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel36);
-            this.flowLayoutPanel26.Controls.Add(this.force60HzCheckBox);
-            this.flowLayoutPanel26.Controls.Add(this.suppressFrameDropCheckBox);
-            this.flowLayoutPanel26.Controls.Add(this.disableThrottlingCheckBox);
-            this.flowLayoutPanel26.Controls.Add(this.disableController);
-            this.flowLayoutPanel26.Controls.Add(this.force3DOFCheckBox);
-            this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel15);
-            this.flowLayoutPanel26.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel26.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanel26.Location = new System.Drawing.Point(414, 13);
-            this.flowLayoutPanel26.Name = "flowLayoutPanel26";
-            this.flowLayoutPanel26.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
-            this.flowLayoutPanel26.Size = new System.Drawing.Size(238, 276);
-            this.flowLayoutPanel26.TabIndex = 40;
-            this.flowLayoutPanel26.WrapContents = false;
-            // 
-            // flowLayoutPanel35
-            // 
-            this.flowLayoutPanel35.Controls.Add(this.steamAutoLaunch);
-            this.flowLayoutPanel35.Controls.Add(this.autoLaunchHelp);
-            this.flowLayoutPanel35.Location = new System.Drawing.Point(5, 21);
-            this.flowLayoutPanel35.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel35.Name = "flowLayoutPanel35";
-            this.flowLayoutPanel35.Size = new System.Drawing.Size(233, 21);
-            this.flowLayoutPanel35.TabIndex = 37;
-            // 
-            // autoLaunchHelp
-            // 
-            this.autoLaunchHelp.AutoSize = true;
-            this.autoLaunchHelp.Location = new System.Drawing.Point(215, 0);
-            this.autoLaunchHelp.Name = "autoLaunchHelp";
-            this.autoLaunchHelp.Size = new System.Drawing.Size(15, 19);
-            this.autoLaunchHelp.TabIndex = 37;
-            this.autoLaunchHelp.Text = "?";
-            this.autoLaunchHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // flowLayoutPanel36
-            // 
-            this.flowLayoutPanel36.AutoSize = true;
-            this.flowLayoutPanel36.Controls.Add(this.launchMinimized);
-            this.flowLayoutPanel36.Location = new System.Drawing.Point(5, 42);
-            this.flowLayoutPanel36.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel36.Name = "flowLayoutPanel36";
-            this.flowLayoutPanel36.Size = new System.Drawing.Size(157, 21);
-            this.flowLayoutPanel36.TabIndex = 38;
-            // 
-            // flowLayoutPanel15
-            // 
-            this.flowLayoutPanel15.AutoSize = true;
-            this.flowLayoutPanel15.Controls.Add(this.aggressiveKeyframeResend);
-            this.flowLayoutPanel15.Controls.Add(this.aggressiveKeyframeResendHelp);
-            this.flowLayoutPanel15.Location = new System.Drawing.Point(5, 168);
-            this.flowLayoutPanel15.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel15.Name = "flowLayoutPanel15";
-            this.flowLayoutPanel15.Size = new System.Drawing.Size(194, 21);
-            this.flowLayoutPanel15.TabIndex = 35;
-            // 
-            // aggressiveKeyframeResendHelp
-            // 
-            this.aggressiveKeyframeResendHelp.AutoSize = true;
-            this.aggressiveKeyframeResendHelp.BackColor = System.Drawing.SystemColors.ControlDark;
-            this.aggressiveKeyframeResendHelp.FontSize = MetroFramework.MetroLabelSize.Small;
-            this.aggressiveKeyframeResendHelp.Location = new System.Drawing.Point(179, 0);
-            this.aggressiveKeyframeResendHelp.Name = "aggressiveKeyframeResendHelp";
-            this.aggressiveKeyframeResendHelp.Size = new System.Drawing.Size(12, 15);
-            this.aggressiveKeyframeResendHelp.Style = MetroFramework.MetroColorStyle.Blue;
-            this.aggressiveKeyframeResendHelp.TabIndex = 0;
-            this.aggressiveKeyframeResendHelp.Text = "?";
-            this.aggressiveKeyframeResendHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // flowLayoutPanel17
-            // 
-            this.flowLayoutPanel17.AutoSize = true;
-            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel17, 2);
-            this.flowLayoutPanel17.Controls.Add(this.metroLabel29);
-            this.flowLayoutPanel17.Controls.Add(this.trackingFrameOffsetTextBox);
-            this.flowLayoutPanel17.Controls.Add(this.saveTrackingFrameOffsetButton);
-            this.flowLayoutPanel17.Controls.Add(this.metroLabel30);
-            this.flowLayoutPanel17.Location = new System.Drawing.Point(3, 376);
-            this.flowLayoutPanel17.Name = "flowLayoutPanel17";
-            this.flowLayoutPanel17.Size = new System.Drawing.Size(609, 38);
-            this.flowLayoutPanel17.TabIndex = 0;
-            this.flowLayoutPanel17.WrapContents = false;
-            // 
-            // metroLabel29
-            // 
-            this.metroLabel29.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel29.AutoSize = true;
-            this.metroLabel29.Location = new System.Drawing.Point(3, 9);
-            this.metroLabel29.Name = "metroLabel29";
-            this.metroLabel29.Size = new System.Drawing.Size(129, 19);
-            this.metroLabel29.TabIndex = 18;
-            this.metroLabel29.Text = "TrackingFrameOffset";
-            // 
-            // saveTrackingFrameOffsetButton
-            // 
-            this.saveTrackingFrameOffsetButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.saveTrackingFrameOffsetButton.Location = new System.Drawing.Point(246, 6);
-            this.saveTrackingFrameOffsetButton.Name = "saveTrackingFrameOffsetButton";
-            this.saveTrackingFrameOffsetButton.Size = new System.Drawing.Size(75, 25);
-            this.saveTrackingFrameOffsetButton.TabIndex = 28;
-            this.saveTrackingFrameOffsetButton.Text = "Save";
-            this.saveTrackingFrameOffsetButton.Click += new System.EventHandler(this.saveTrackingFrameOffsetButton_Click);
-            // 
-            // metroLabel30
-            // 
-            this.metroLabel30.AutoSize = true;
-            this.metroLabel30.Location = new System.Drawing.Point(327, 0);
-            this.metroLabel30.Name = "metroLabel30";
-            this.metroLabel30.Size = new System.Drawing.Size(279, 38);
-            this.metroLabel30.TabIndex = 18;
-            this.metroLabel30.Text = "Try \"-1\" if you exceprience jerky head-tracking.\r\nPut \"0\" on if you have no probl" +
-    "em.";
-            // 
-            // flowLayoutPanel24
-            // 
-            this.flowLayoutPanel24.AutoSize = true;
-            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel24, 2);
-            this.flowLayoutPanel24.Controls.Add(this.metroLabel27);
-            this.flowLayoutPanel24.Controls.Add(this.connectCommandTextBox);
-            this.flowLayoutPanel24.Controls.Add(this.refConnectCommandButton);
-            this.flowLayoutPanel24.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel24.Location = new System.Drawing.Point(0, 311);
-            this.flowLayoutPanel24.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel24.Name = "flowLayoutPanel24";
-            this.flowLayoutPanel24.Size = new System.Drawing.Size(655, 31);
-            this.flowLayoutPanel24.TabIndex = 41;
-            // 
-            // metroLabel27
-            // 
-            this.metroLabel27.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel27.AutoSize = true;
-            this.metroLabel27.Location = new System.Drawing.Point(3, 6);
-            this.metroLabel27.Name = "metroLabel27";
-            this.metroLabel27.Size = new System.Drawing.Size(76, 19);
-            this.metroLabel27.TabIndex = 17;
-            this.metroLabel27.Text = "On connect";
-            // 
-            // refConnectCommandButton
-            // 
-            this.refConnectCommandButton.Location = new System.Drawing.Point(442, 3);
-            this.refConnectCommandButton.Name = "refConnectCommandButton";
-            this.refConnectCommandButton.Size = new System.Drawing.Size(52, 25);
-            this.refConnectCommandButton.TabIndex = 24;
-            this.refConnectCommandButton.Text = "...";
-            this.refConnectCommandButton.Click += new System.EventHandler(this.refConnectCommandButton_Click);
-            // 
-            // metroLabel26
-            // 
-            this.metroLabel26.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel26.AutoSize = true;
-            this.metroLabel26.FontWeight = MetroFramework.MetroLabelWeight.Regular;
-            this.metroLabel26.Location = new System.Drawing.Point(3, 292);
-            this.metroLabel26.Name = "metroLabel26";
-            this.metroLabel26.Size = new System.Drawing.Size(101, 19);
-            this.metroLabel26.TabIndex = 3;
-            this.metroLabel26.Text = "Run command:";
-            // 
-            // flowLayoutPanel25
-            // 
-            this.flowLayoutPanel25.AutoSize = true;
-            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel25, 2);
-            this.flowLayoutPanel25.Controls.Add(this.metroLabel28);
-            this.flowLayoutPanel25.Controls.Add(this.disconnectCommandTextBox);
-            this.flowLayoutPanel25.Controls.Add(this.refDisconnectCommandButton);
-            this.flowLayoutPanel25.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel25.Location = new System.Drawing.Point(0, 342);
-            this.flowLayoutPanel25.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel25.Name = "flowLayoutPanel25";
-            this.flowLayoutPanel25.Size = new System.Drawing.Size(655, 31);
-            this.flowLayoutPanel25.TabIndex = 42;
-            // 
-            // metroLabel28
-            // 
-            this.metroLabel28.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel28.AutoSize = true;
-            this.metroLabel28.Location = new System.Drawing.Point(3, 6);
-            this.metroLabel28.Name = "metroLabel28";
-            this.metroLabel28.Size = new System.Drawing.Size(92, 19);
-            this.metroLabel28.TabIndex = 17;
-            this.metroLabel28.Text = "On disconnect";
-            // 
-            // refDisconnectCommandButton
-            // 
-            this.refDisconnectCommandButton.Location = new System.Drawing.Point(490, 3);
-            this.refDisconnectCommandButton.Name = "refDisconnectCommandButton";
-            this.refDisconnectCommandButton.Size = new System.Drawing.Size(52, 25);
-            this.refDisconnectCommandButton.TabIndex = 26;
-            this.refDisconnectCommandButton.Text = "...";
-            this.refDisconnectCommandButton.Click += new System.EventHandler(this.refDisconnectCommandButton_Click);
-            // 
-            // tableLayoutPanel3
-            // 
-            this.tableLayoutPanel3.AutoSize = true;
-            this.tableLayoutPanel3.ColumnCount = 1;
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel43, 0, 4);
-            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel37, 0, 3);
-            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel38, 0, 2);
-            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel16, 0, 1);
-            this.tableLayoutPanel3.Controls.Add(this.metroLabel41, 0, 0);
-            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 13);
-            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 6;
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(405, 276);
-            this.tableLayoutPanel3.TabIndex = 44;
-            // 
-            // flowLayoutPanel43
-            // 
-            this.flowLayoutPanel43.AutoSize = true;
-            this.flowLayoutPanel43.Controls.Add(this.metroLabel40);
-            this.flowLayoutPanel43.Controls.Add(this.controllerRotationOffsetHelp);
-            this.flowLayoutPanel43.Controls.Add(this.numericUpDown4);
-            this.flowLayoutPanel43.Controls.Add(this.numericUpDown5);
-            this.flowLayoutPanel43.Controls.Add(this.numericUpDown6);
-            this.flowLayoutPanel43.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel43.Location = new System.Drawing.Point(3, 132);
-            this.flowLayoutPanel43.Name = "flowLayoutPanel43";
-            this.flowLayoutPanel43.Size = new System.Drawing.Size(399, 26);
-            this.flowLayoutPanel43.TabIndex = 39;
-            // 
-            // metroLabel40
-            // 
-            this.metroLabel40.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel40.AutoSize = true;
-            this.metroLabel40.Location = new System.Drawing.Point(3, 3);
-            this.metroLabel40.Name = "metroLabel40";
-            this.metroLabel40.Size = new System.Drawing.Size(210, 19);
-            this.metroLabel40.TabIndex = 0;
-            this.metroLabel40.Text = "Left rotation offset (pitch, yaw, roll)";
-            // 
-            // controllerRotationOffsetHelp
-            // 
-            this.controllerRotationOffsetHelp.AutoSize = true;
-            this.controllerRotationOffsetHelp.Location = new System.Drawing.Point(219, 0);
-            this.controllerRotationOffsetHelp.Name = "controllerRotationOffsetHelp";
-            this.controllerRotationOffsetHelp.Size = new System.Drawing.Size(15, 19);
-            this.controllerRotationOffsetHelp.TabIndex = 52;
-            this.controllerRotationOffsetHelp.Text = "?";
-            this.controllerRotationOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // flowLayoutPanel37
-            // 
-            this.flowLayoutPanel37.AutoSize = true;
-            this.flowLayoutPanel37.Controls.Add(this.metroLabel39);
-            this.flowLayoutPanel37.Controls.Add(this.controllerPositionOffsetHelp);
-            this.flowLayoutPanel37.Controls.Add(this.numericUpDown1);
-            this.flowLayoutPanel37.Controls.Add(this.numericUpDown2);
-            this.flowLayoutPanel37.Controls.Add(this.numericUpDown3);
-            this.flowLayoutPanel37.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel37.Location = new System.Drawing.Point(3, 100);
-            this.flowLayoutPanel37.Name = "flowLayoutPanel37";
-            this.flowLayoutPanel37.Size = new System.Drawing.Size(399, 26);
-            this.flowLayoutPanel37.TabIndex = 38;
-            // 
-            // metroLabel39
-            // 
-            this.metroLabel39.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel39.AutoSize = true;
-            this.metroLabel39.Location = new System.Drawing.Point(3, 3);
-            this.metroLabel39.Name = "metroLabel39";
-            this.metroLabel39.Size = new System.Drawing.Size(159, 19);
-            this.metroLabel39.TabIndex = 0;
-            this.metroLabel39.Text = "Left position offset (x, y, z)";
-            // 
-            // controllerPositionOffsetHelp
-            // 
-            this.controllerPositionOffsetHelp.AutoSize = true;
-            this.controllerPositionOffsetHelp.Location = new System.Drawing.Point(168, 0);
-            this.controllerPositionOffsetHelp.Name = "controllerPositionOffsetHelp";
-            this.controllerPositionOffsetHelp.Size = new System.Drawing.Size(15, 19);
-            this.controllerPositionOffsetHelp.TabIndex = 52;
-            this.controllerPositionOffsetHelp.Text = "?";
-            this.controllerPositionOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // flowLayoutPanel38
-            // 
-            this.flowLayoutPanel38.AutoSize = true;
-            this.flowLayoutPanel38.Controls.Add(this.metroLabel36);
-            this.flowLayoutPanel38.Controls.Add(this.handTrackingModeHelp);
-            this.flowLayoutPanel38.Controls.Add(this.controllerModeComboBox);
-            this.flowLayoutPanel38.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel38.Location = new System.Drawing.Point(3, 59);
-            this.flowLayoutPanel38.Name = "flowLayoutPanel38";
-            this.flowLayoutPanel38.Size = new System.Drawing.Size(399, 35);
-            this.flowLayoutPanel38.TabIndex = 0;
-            // 
-            // metroLabel36
-            // 
-            this.metroLabel36.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel36.AutoSize = true;
-            this.metroLabel36.Location = new System.Drawing.Point(3, 8);
-            this.metroLabel36.Name = "metroLabel36";
-            this.metroLabel36.Size = new System.Drawing.Size(129, 19);
-            this.metroLabel36.TabIndex = 0;
-            this.metroLabel36.Text = "Hand tracking mode";
-            // 
-            // handTrackingModeHelp
-            // 
-            this.handTrackingModeHelp.AutoSize = true;
-            this.handTrackingModeHelp.Location = new System.Drawing.Point(138, 0);
-            this.handTrackingModeHelp.Name = "handTrackingModeHelp";
-            this.handTrackingModeHelp.Size = new System.Drawing.Size(15, 19);
-            this.handTrackingModeHelp.TabIndex = 53;
-            this.handTrackingModeHelp.Text = "?";
-            this.handTrackingModeHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // controllerModeComboBox
-            // 
-            this.controllerModeComboBox.FormattingEnabled = true;
-            this.controllerModeComboBox.ItemHeight = 23;
-            this.controllerModeComboBox.Location = new System.Drawing.Point(159, 3);
-            this.controllerModeComboBox.Name = "controllerModeComboBox";
-            this.controllerModeComboBox.Size = new System.Drawing.Size(232, 29);
-            this.controllerModeComboBox.TabIndex = 1;
-            this.controllerModeComboBox.SelectedIndexChanged += new System.EventHandler(this.metroComboBox1_SelectedIndexChanged);
-            // 
-            // flowLayoutPanel16
-            // 
-            this.flowLayoutPanel16.AutoSize = true;
-            this.flowLayoutPanel16.Controls.Add(this.metroLabel12);
-            this.flowLayoutPanel16.Controls.Add(this.controllerPoseOffset);
-            this.flowLayoutPanel16.Controls.Add(this.metroButton1);
-            this.flowLayoutPanel16.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel16.Location = new System.Drawing.Point(3, 22);
-            this.flowLayoutPanel16.Name = "flowLayoutPanel16";
-            this.flowLayoutPanel16.Size = new System.Drawing.Size(399, 31);
-            this.flowLayoutPanel16.TabIndex = 37;
-            this.flowLayoutPanel16.WrapContents = false;
-            // 
-            // metroLabel12
-            // 
-            this.metroLabel12.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel12.AutoSize = true;
-            this.metroLabel12.Location = new System.Drawing.Point(3, 6);
-            this.metroLabel12.Name = "metroLabel12";
-            this.metroLabel12.Size = new System.Drawing.Size(102, 19);
-            this.metroLabel12.TabIndex = 20;
-            this.metroLabel12.Text = "Pose time offset";
-            this.metroLabel12.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // metroButton1
-            // 
-            this.metroButton1.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroButton1.Location = new System.Drawing.Point(169, 3);
-            this.metroButton1.Name = "metroButton1";
-            this.metroButton1.Size = new System.Drawing.Size(75, 25);
-            this.metroButton1.TabIndex = 22;
-            this.metroButton1.Text = "Save";
-            this.metroButton1.Click += new System.EventHandler(this.metroButton1_Click);
-            // 
-            // metroLabel41
-            // 
-            this.metroLabel41.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel41.AutoSize = true;
-            this.metroLabel41.FontWeight = MetroFramework.MetroLabelWeight.Regular;
-            this.metroLabel41.Location = new System.Drawing.Point(3, 0);
-            this.metroLabel41.Name = "metroLabel41";
-            this.metroLabel41.Size = new System.Drawing.Size(125, 19);
-            this.metroLabel41.TabIndex = 40;
-            this.metroLabel41.Text = "Controller settings:";
-            this.metroLabel41.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // presetsTab
-            // 
-            this.presetsTab.Controls.Add(this.tableLayoutPanel2);
-            this.presetsTab.HorizontalScrollbarBarColor = true;
-            this.presetsTab.HorizontalScrollbarSize = 0;
-            this.presetsTab.Location = new System.Drawing.Point(4, 35);
-            this.presetsTab.Name = "presetsTab";
-            this.presetsTab.Size = new System.Drawing.Size(655, 417);
-            this.presetsTab.TabIndex = 9;
-            this.presetsTab.Text = "Presets";
-            this.presetsTab.VerticalScrollbarBarColor = true;
-            this.presetsTab.VerticalScrollbarSize = 0;
-            // 
-            // tableLayoutPanel2
-            // 
-            this.tableLayoutPanel2.BackColor = System.Drawing.SystemColors.Window;
-            this.tableLayoutPanel2.ColumnCount = 2;
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.Controls.Add(this.metroLabel38, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel42, 1, 0);
-            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
-            this.tableLayoutPanel2.RowCount = 2;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(655, 417);
-            this.tableLayoutPanel2.TabIndex = 9;
-            // 
-            // metroLabel38
-            // 
-            this.metroLabel38.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.metroLabel38.AutoSize = true;
-            this.metroLabel38.Location = new System.Drawing.Point(46, 19);
-            this.metroLabel38.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.metroLabel38.Name = "metroLabel38";
-            this.metroLabel38.Size = new System.Drawing.Size(54, 19);
-            this.metroLabel38.TabIndex = 27;
-            this.metroLabel38.Text = "General";
-            // 
-            // flowLayoutPanel42
-            // 
-            this.flowLayoutPanel42.AutoSize = true;
-            this.flowLayoutPanel42.Controls.Add(this.revertToDefaultButton);
-            this.flowLayoutPanel42.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel42.Location = new System.Drawing.Point(103, 13);
-            this.flowLayoutPanel42.Name = "flowLayoutPanel42";
-            this.flowLayoutPanel42.Size = new System.Drawing.Size(549, 31);
-            this.flowLayoutPanel42.TabIndex = 26;
-            // 
-            // revertToDefaultButton
-            // 
-            this.revertToDefaultButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.revertToDefaultButton.Location = new System.Drawing.Point(3, 3);
-            this.revertToDefaultButton.Name = "revertToDefaultButton";
-            this.revertToDefaultButton.Size = new System.Drawing.Size(163, 25);
-            this.revertToDefaultButton.TabIndex = 23;
-            this.revertToDefaultButton.Text = "Revert all settings to default";
-            this.revertToDefaultButton.Click += new System.EventHandler(this.revertToDefaultButton_Click);
+            // defaultSoundDeviceCheckBox
+            // 
+            this.defaultSoundDeviceCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.defaultSoundDeviceCheckBox.AutoSize = true;
+            this.defaultSoundDeviceCheckBox.Checked = global::ALVR.Properties.Settings.Default.useDefaultSoundDevice;
+            this.defaultSoundDeviceCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.defaultSoundDeviceCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "useDefaultSoundDevice", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.defaultSoundDeviceCheckBox.Location = new System.Drawing.Point(20, 41);
+            this.defaultSoundDeviceCheckBox.Margin = new System.Windows.Forms.Padding(20, 3, 3, 3);
+            this.defaultSoundDeviceCheckBox.Name = "defaultSoundDeviceCheckBox";
+            this.defaultSoundDeviceCheckBox.Size = new System.Drawing.Size(119, 15);
+            this.defaultSoundDeviceCheckBox.TabIndex = 2;
+            this.defaultSoundDeviceCheckBox.Text = "Use default device";
+            this.defaultSoundDeviceCheckBox.UseVisualStyleBackColor = true;
+            this.defaultSoundDeviceCheckBox.CheckedChanged += new System.EventHandler(this.defaultSoundDeviceCheckBox_CheckedChanged);
             // 
             // debugTab
             // 
@@ -2330,6 +2910,18 @@
             this.flowLayoutPanel21.Size = new System.Drawing.Size(349, 209);
             this.flowLayoutPanel21.TabIndex = 15;
             // 
+            // debugLogCheckBox
+            // 
+            this.debugLogCheckBox.AutoSize = true;
+            this.debugLogCheckBox.Checked = global::ALVR.Properties.Settings.Default.debugLog;
+            this.debugLogCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "debugLog", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.debugLogCheckBox.Location = new System.Drawing.Point(3, 3);
+            this.debugLogCheckBox.Name = "debugLogCheckBox";
+            this.debugLogCheckBox.Size = new System.Drawing.Size(78, 15);
+            this.debugLogCheckBox.TabIndex = 9;
+            this.debugLogCheckBox.Text = "DebugLog";
+            this.debugLogCheckBox.UseVisualStyleBackColor = true;
+            // 
             // metroCheckBox1
             // 
             this.metroCheckBox1.AutoSize = true;
@@ -2339,6 +2931,18 @@
             this.metroCheckBox1.TabIndex = 9;
             this.metroCheckBox1.Text = "DebugFrameIndex";
             this.metroCheckBox1.UseVisualStyleBackColor = true;
+            // 
+            // debugCaptureOutputCheckBox
+            // 
+            this.debugCaptureOutputCheckBox.AutoSize = true;
+            this.debugCaptureOutputCheckBox.Checked = global::ALVR.Properties.Settings.Default.debugCaptureOutput;
+            this.debugCaptureOutputCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "debugCaptureOutput", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.debugCaptureOutputCheckBox.Location = new System.Drawing.Point(3, 24);
+            this.debugCaptureOutputCheckBox.Name = "debugCaptureOutputCheckBox";
+            this.debugCaptureOutputCheckBox.Size = new System.Drawing.Size(138, 15);
+            this.debugCaptureOutputCheckBox.TabIndex = 9;
+            this.debugCaptureOutputCheckBox.Text = "DebugCaptureOutput";
+            this.debugCaptureOutputCheckBox.UseVisualStyleBackColor = true;
             // 
             // metroCheckBox2
             // 
@@ -2588,572 +3192,6 @@
             this.notifyIcon1.Text = "ALVR";
             this.notifyIcon1.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.notifyIcon1_MouseDoubleClick);
             // 
-            // sharpeningBox
-            // 
-            this.sharpeningBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "sharpening", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.sharpeningBox.DecimalPlaces = 2;
-            this.sharpeningBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.sharpeningBox.Location = new System.Drawing.Point(82, 3);
-            this.sharpeningBox.Maximum = new decimal(new int[] {
-            500,
-            0,
-            0,
-            131072});
-            this.sharpeningBox.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.sharpeningBox.Name = "sharpeningBox";
-            this.sharpeningBox.Size = new System.Drawing.Size(44, 20);
-            this.sharpeningBox.TabIndex = 44;
-            this.sharpeningBox.Value = global::ALVR.Properties.Settings.Default.sharpening;
-            // 
-            // forceNV12
-            // 
-            this.forceNV12.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.forceNV12.AutoSize = true;
-            this.forceNV12.Checked = global::ALVR.Properties.Settings.Default.nv12;
-            this.forceNV12.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "nv12", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.forceNV12.Location = new System.Drawing.Point(3, 3);
-            this.forceNV12.Margin = new System.Windows.Forms.Padding(3, 3, 0, 3);
-            this.forceNV12.Name = "forceNV12";
-            this.forceNV12.Size = new System.Drawing.Size(115, 15);
-            this.forceNV12.TabIndex = 35;
-            this.forceNV12.Text = "use custom NV12";
-            this.forceNV12.UseVisualStyleBackColor = true;
-            // 
-            // bitrateTrackBar
-            // 
-            this.bitrateTrackBar.BackColor = System.Drawing.Color.Transparent;
-            this.bitrateTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "bitrate", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.bitrateTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.bitrateTrackBar.Location = new System.Drawing.Point(233, 73);
-            this.bitrateTrackBar.Maximum = 250;
-            this.bitrateTrackBar.Minimum = 1;
-            this.bitrateTrackBar.Name = "bitrateTrackBar";
-            this.bitrateTrackBar.Size = new System.Drawing.Size(269, 25);
-            this.bitrateTrackBar.TabIndex = 2;
-            this.bitrateTrackBar.Text = "metroTrackBar1";
-            this.bitrateTrackBar.Value = global::ALVR.Properties.Settings.Default.bitrate;
-            this.bitrateTrackBar.ValueChanged += new System.EventHandler(this.bitrateTrackBar_ValueChanged);
-            this.bitrateTrackBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.bitrateTrackBar_Scroll);
-            // 
-            // enableColorCorrectionCheckBox
-            // 
-            this.enableColorCorrectionCheckBox.AutoSize = true;
-            this.enableColorCorrectionCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableColorCorrection;
-            this.enableColorCorrectionCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableColorCorrection", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.enableColorCorrectionCheckBox.Location = new System.Drawing.Point(233, 295);
-            this.enableColorCorrectionCheckBox.Name = "enableColorCorrectionCheckBox";
-            this.enableColorCorrectionCheckBox.Size = new System.Drawing.Size(58, 15);
-            this.enableColorCorrectionCheckBox.TabIndex = 40;
-            this.enableColorCorrectionCheckBox.Text = "Enable";
-            this.enableColorCorrectionCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // bufferTrackBar
-            // 
-            this.bufferTrackBar.BackColor = System.Drawing.Color.Transparent;
-            this.bufferTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "bufferOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.bufferTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.bufferTrackBar.Location = new System.Drawing.Point(233, 160);
-            this.bufferTrackBar.Minimum = -100;
-            this.bufferTrackBar.Name = "bufferTrackBar";
-            this.bufferTrackBar.Size = new System.Drawing.Size(269, 20);
-            this.bufferTrackBar.TabIndex = 2;
-            this.bufferTrackBar.Text = "metroTrackBar1";
-            this.bufferTrackBar.Value = global::ALVR.Properties.Settings.Default.bufferOffset;
-            this.bufferTrackBar.ValueChanged += new System.EventHandler(this.bufferTrackBar_ValueChanged);
-            this.bufferTrackBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.bufferTrackBar_Scroll);
-            // 
-            // foveationStrengthTrackBar
-            // 
-            this.foveationStrengthTrackBar.BackColor = System.Drawing.Color.Transparent;
-            this.foveationStrengthTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "foveationStrength", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.foveationStrengthTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.foveationStrengthTrackBar.LargeChange = 100;
-            this.foveationStrengthTrackBar.Location = new System.Drawing.Point(233, 240);
-            this.foveationStrengthTrackBar.Maximum = 500;
-            this.foveationStrengthTrackBar.MaximumSize = new System.Drawing.Size(0, 14);
-            this.foveationStrengthTrackBar.Name = "foveationStrengthTrackBar";
-            this.foveationStrengthTrackBar.Size = new System.Drawing.Size(269, 10);
-            this.foveationStrengthTrackBar.SmallChange = 10;
-            this.foveationStrengthTrackBar.TabIndex = 30;
-            this.foveationStrengthTrackBar.Text = "metroTrackBar1";
-            this.foveationStrengthTrackBar.Value = global::ALVR.Properties.Settings.Default.foveationStrength;
-            this.foveationStrengthTrackBar.ValueChanged += new System.EventHandler(this.FoveationStrengthTrackBar_ValueChanged);
-            // 
-            // foveationVerticalOffsetTrackBar
-            // 
-            this.foveationVerticalOffsetTrackBar.BackColor = System.Drawing.Color.Transparent;
-            this.foveationVerticalOffsetTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "foveationVerticalOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.foveationVerticalOffsetTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.foveationVerticalOffsetTrackBar.LargeChange = 2;
-            this.foveationVerticalOffsetTrackBar.Location = new System.Drawing.Point(233, 275);
-            this.foveationVerticalOffsetTrackBar.Maximum = 10;
-            this.foveationVerticalOffsetTrackBar.Minimum = -10;
-            this.foveationVerticalOffsetTrackBar.MouseWheelBarPartitions = 1;
-            this.foveationVerticalOffsetTrackBar.Name = "foveationVerticalOffsetTrackBar";
-            this.foveationVerticalOffsetTrackBar.Size = new System.Drawing.Size(269, 14);
-            this.foveationVerticalOffsetTrackBar.TabIndex = 34;
-            this.foveationVerticalOffsetTrackBar.Text = "metroTrackBar1";
-            this.foveationVerticalOffsetTrackBar.Value = global::ALVR.Properties.Settings.Default.foveationVerticalOffset;
-            this.foveationVerticalOffsetTrackBar.ValueChanged += new System.EventHandler(this.FoveationVerticalOffsetTrackBar_ValueChanged);
-            // 
-            // saturationBox
-            // 
-            this.saturationBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "saturation", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.saturationBox.DecimalPlaces = 2;
-            this.saturationBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.saturationBox.Location = new System.Drawing.Point(75, 3);
-            this.saturationBox.Maximum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.saturationBox.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            -2147483648});
-            this.saturationBox.Name = "saturationBox";
-            this.saturationBox.Size = new System.Drawing.Size(46, 20);
-            this.saturationBox.TabIndex = 48;
-            this.saturationBox.Value = global::ALVR.Properties.Settings.Default.saturation;
-            // 
-            // contrastBox
-            // 
-            this.contrastBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "contrast", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.contrastBox.DecimalPlaces = 2;
-            this.contrastBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.contrastBox.Location = new System.Drawing.Point(65, 3);
-            this.contrastBox.Maximum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            131072});
-            this.contrastBox.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.contrastBox.Name = "contrastBox";
-            this.contrastBox.Size = new System.Drawing.Size(45, 20);
-            this.contrastBox.TabIndex = 46;
-            this.contrastBox.Value = global::ALVR.Properties.Settings.Default.contrast;
-            // 
-            // brightnessBox
-            // 
-            this.brightnessBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "brightness", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.brightnessBox.DecimalPlaces = 2;
-            this.brightnessBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.brightnessBox.Location = new System.Drawing.Point(75, 3);
-            this.brightnessBox.Maximum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            131072});
-            this.brightnessBox.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.brightnessBox.Name = "brightnessBox";
-            this.brightnessBox.Size = new System.Drawing.Size(44, 20);
-            this.brightnessBox.TabIndex = 44;
-            this.brightnessBox.Value = global::ALVR.Properties.Settings.Default.brightness;
-            // 
-            // gammaBox
-            // 
-            this.gammaBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "gamma", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.gammaBox.DecimalPlaces = 2;
-            this.gammaBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.gammaBox.Location = new System.Drawing.Point(63, 3);
-            this.gammaBox.Maximum = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
-            this.gammaBox.Name = "gammaBox";
-            this.gammaBox.Size = new System.Drawing.Size(45, 20);
-            this.gammaBox.TabIndex = 42;
-            this.gammaBox.Value = global::ALVR.Properties.Settings.Default.gamma;
-            // 
-            // soundCheckBox
-            // 
-            this.soundCheckBox.AutoSize = true;
-            this.soundCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableSound;
-            this.soundCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.soundCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableSound", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.soundCheckBox.Location = new System.Drawing.Point(3, 3);
-            this.soundCheckBox.Name = "soundCheckBox";
-            this.soundCheckBox.Size = new System.Drawing.Size(92, 15);
-            this.soundCheckBox.TabIndex = 2;
-            this.soundCheckBox.Text = "Steam sound";
-            this.soundCheckBox.UseVisualStyleBackColor = true;
-            this.soundCheckBox.CheckedChanged += new System.EventHandler(this.soundCheckBox_CheckedChanged);
-            // 
-            // streamMic
-            // 
-            this.streamMic.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.streamMic.AutoSize = true;
-            this.streamMic.Checked = global::ALVR.Properties.Settings.Default.streamMic;
-            this.streamMic.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "streamMic", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.streamMic.Location = new System.Drawing.Point(3, 73);
-            this.streamMic.Name = "streamMic";
-            this.streamMic.Size = new System.Drawing.Size(162, 15);
-            this.streamMic.TabIndex = 5;
-            this.streamMic.Text = "Stream Quest Microphone";
-            this.streamMic.UseVisualStyleBackColor = true;
-            this.streamMic.CheckedChanged += new System.EventHandler(this.metroCheckBox4_CheckedChanged);
-            // 
-            // defaultSoundDeviceCheckBox
-            // 
-            this.defaultSoundDeviceCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.defaultSoundDeviceCheckBox.AutoSize = true;
-            this.defaultSoundDeviceCheckBox.Checked = global::ALVR.Properties.Settings.Default.useDefaultSoundDevice;
-            this.defaultSoundDeviceCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.defaultSoundDeviceCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "useDefaultSoundDevice", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.defaultSoundDeviceCheckBox.Location = new System.Drawing.Point(20, 41);
-            this.defaultSoundDeviceCheckBox.Margin = new System.Windows.Forms.Padding(20, 3, 3, 3);
-            this.defaultSoundDeviceCheckBox.Name = "defaultSoundDeviceCheckBox";
-            this.defaultSoundDeviceCheckBox.Size = new System.Drawing.Size(119, 15);
-            this.defaultSoundDeviceCheckBox.TabIndex = 2;
-            this.defaultSoundDeviceCheckBox.Text = "Use default device";
-            this.defaultSoundDeviceCheckBox.UseVisualStyleBackColor = true;
-            this.defaultSoundDeviceCheckBox.CheckedChanged += new System.EventHandler(this.defaultSoundDeviceCheckBox_CheckedChanged);
-            // 
-            // onlySteamVRCheckBox
-            // 
-            this.onlySteamVRCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.onlySteamVRCheckBox.AutoSize = true;
-            this.onlySteamVRCheckBox.Checked = global::ALVR.Properties.Settings.Default.onlySteamVR;
-            this.onlySteamVRCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "onlySteamVR", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.onlySteamVRCheckBox.Location = new System.Drawing.Point(8, 3);
-            this.onlySteamVRCheckBox.Name = "onlySteamVRCheckBox";
-            this.onlySteamVRCheckBox.Size = new System.Drawing.Size(221, 15);
-            this.onlySteamVRCheckBox.TabIndex = 29;
-            this.onlySteamVRCheckBox.Text = "Launch only SteamVR without Steam.";
-            this.onlySteamVRCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // steamAutoLaunch
-            // 
-            this.steamAutoLaunch.AutoSize = true;
-            this.steamAutoLaunch.Checked = global::ALVR.Properties.Settings.Default.steamAutolaunch;
-            this.steamAutoLaunch.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "steamAutolaunch", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.steamAutoLaunch.Location = new System.Drawing.Point(3, 3);
-            this.steamAutoLaunch.Name = "steamAutoLaunch";
-            this.steamAutoLaunch.Size = new System.Drawing.Size(206, 15);
-            this.steamAutoLaunch.TabIndex = 36;
-            this.steamAutoLaunch.Text = "Launch SteamVR on HMD connect";
-            this.steamAutoLaunch.UseVisualStyleBackColor = true;
-            // 
-            // launchMinimized
-            // 
-            this.launchMinimized.AutoSize = true;
-            this.launchMinimized.Checked = global::ALVR.Properties.Settings.Default.launchMinimized;
-            this.launchMinimized.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "launchMinimized", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.launchMinimized.Location = new System.Drawing.Point(3, 3);
-            this.launchMinimized.Name = "launchMinimized";
-            this.launchMinimized.Size = new System.Drawing.Size(151, 15);
-            this.launchMinimized.TabIndex = 0;
-            this.launchMinimized.Text = "Launch ALVR minimized";
-            this.launchMinimized.UseVisualStyleBackColor = true;
-            // 
-            // force60HzCheckBox
-            // 
-            this.force60HzCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.force60HzCheckBox.AutoSize = true;
-            this.force60HzCheckBox.Checked = global::ALVR.Properties.Settings.Default.force60Hz;
-            this.force60HzCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force60Hz", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.force60HzCheckBox.Location = new System.Drawing.Point(8, 66);
-            this.force60HzCheckBox.Name = "force60HzCheckBox";
-            this.force60HzCheckBox.Size = new System.Drawing.Size(81, 15);
-            this.force60HzCheckBox.TabIndex = 31;
-            this.force60HzCheckBox.Text = "Force 60Hz";
-            this.force60HzCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // suppressFrameDropCheckBox
-            // 
-            this.suppressFrameDropCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.suppressFrameDropCheckBox.AutoSize = true;
-            this.suppressFrameDropCheckBox.Checked = global::ALVR.Properties.Settings.Default.suppressFrameDrop;
-            this.suppressFrameDropCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "suppressFrameDrop", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.suppressFrameDropCheckBox.Location = new System.Drawing.Point(8, 87);
-            this.suppressFrameDropCheckBox.Name = "suppressFrameDropCheckBox";
-            this.suppressFrameDropCheckBox.Size = new System.Drawing.Size(132, 15);
-            this.suppressFrameDropCheckBox.TabIndex = 30;
-            this.suppressFrameDropCheckBox.Text = "Suppress frame drop";
-            this.suppressFrameDropCheckBox.UseVisualStyleBackColor = true;
-            this.suppressFrameDropCheckBox.CheckedChanged += new System.EventHandler(this.suppressFrameDropCheckBox_CheckedChanged);
-            // 
-            // disableThrottlingCheckBox
-            // 
-            this.disableThrottlingCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.disableThrottlingCheckBox.AutoSize = true;
-            this.disableThrottlingCheckBox.Checked = global::ALVR.Properties.Settings.Default.disableThrottling;
-            this.disableThrottlingCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableThrottling", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.disableThrottlingCheckBox.Location = new System.Drawing.Point(8, 108);
-            this.disableThrottlingCheckBox.Name = "disableThrottlingCheckBox";
-            this.disableThrottlingCheckBox.Size = new System.Drawing.Size(142, 15);
-            this.disableThrottlingCheckBox.TabIndex = 32;
-            this.disableThrottlingCheckBox.Text = "Disable send throttling";
-            this.disableThrottlingCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // disableController
-            // 
-            this.disableController.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.disableController.AutoSize = true;
-            this.disableController.Checked = global::ALVR.Properties.Settings.Default.disableController;
-            this.disableController.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableController", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.disableController.Location = new System.Drawing.Point(8, 129);
-            this.disableController.Name = "disableController";
-            this.disableController.Size = new System.Drawing.Size(115, 15);
-            this.disableController.TabIndex = 33;
-            this.disableController.Text = "Disable controller";
-            this.disableController.UseVisualStyleBackColor = true;
-            // 
-            // force3DOFCheckBox
-            // 
-            this.force3DOFCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.force3DOFCheckBox.AutoSize = true;
-            this.force3DOFCheckBox.Checked = global::ALVR.Properties.Settings.Default.force3DOF;
-            this.force3DOFCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force3DOF", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.force3DOFCheckBox.Location = new System.Drawing.Point(8, 150);
-            this.force3DOFCheckBox.Name = "force3DOFCheckBox";
-            this.force3DOFCheckBox.Size = new System.Drawing.Size(84, 15);
-            this.force3DOFCheckBox.TabIndex = 34;
-            this.force3DOFCheckBox.Text = "Force 3DOF";
-            this.force3DOFCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // aggressiveKeyframeResend
-            // 
-            this.aggressiveKeyframeResend.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.aggressiveKeyframeResend.AutoSize = true;
-            this.aggressiveKeyframeResend.Checked = global::ALVR.Properties.Settings.Default.aggressiveKeyframeResend;
-            this.aggressiveKeyframeResend.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "aggressiveKeyframeResend", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.aggressiveKeyframeResend.Location = new System.Drawing.Point(3, 3);
-            this.aggressiveKeyframeResend.Name = "aggressiveKeyframeResend";
-            this.aggressiveKeyframeResend.Size = new System.Drawing.Size(170, 15);
-            this.aggressiveKeyframeResend.TabIndex = 35;
-            this.aggressiveKeyframeResend.Text = "Aggressive keyframe resend";
-            this.aggressiveKeyframeResend.UseVisualStyleBackColor = true;
-            // 
-            // trackingFrameOffsetTextBox
-            // 
-            this.trackingFrameOffsetTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.trackingFrameOffsetTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "trackingFrameOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.trackingFrameOffsetTextBox.Location = new System.Drawing.Point(138, 6);
-            this.trackingFrameOffsetTextBox.Name = "trackingFrameOffsetTextBox";
-            this.trackingFrameOffsetTextBox.Size = new System.Drawing.Size(102, 25);
-            this.trackingFrameOffsetTextBox.TabIndex = 27;
-            this.trackingFrameOffsetTextBox.Text = global::ALVR.Properties.Settings.Default.trackingFrameOffset;
-            // 
-            // connectCommandTextBox
-            // 
-            this.connectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "connectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.connectCommandTextBox.Location = new System.Drawing.Point(85, 3);
-            this.connectCommandTextBox.Name = "connectCommandTextBox";
-            this.connectCommandTextBox.Size = new System.Drawing.Size(351, 25);
-            this.connectCommandTextBox.TabIndex = 23;
-            this.connectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.connectCommand;
-            // 
-            // disconnectCommandTextBox
-            // 
-            this.disconnectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "disconnectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.disconnectCommandTextBox.Location = new System.Drawing.Point(101, 3);
-            this.disconnectCommandTextBox.Name = "disconnectCommandTextBox";
-            this.disconnectCommandTextBox.Size = new System.Drawing.Size(383, 25);
-            this.disconnectCommandTextBox.TabIndex = 25;
-            this.disconnectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.disconnectCommand;
-            // 
-            // numericUpDown4
-            // 
-            this.numericUpDown4.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPitchOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.numericUpDown4.Location = new System.Drawing.Point(240, 3);
-            this.numericUpDown4.Maximum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            0});
-            this.numericUpDown4.Minimum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            -2147483648});
-            this.numericUpDown4.Name = "numericUpDown4";
-            this.numericUpDown4.Size = new System.Drawing.Size(45, 20);
-            this.numericUpDown4.TabIndex = 54;
-            this.numericUpDown4.Value = global::ALVR.Properties.Settings.Default.leftControllerPitchOffset;
-            // 
-            // numericUpDown5
-            // 
-            this.numericUpDown5.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerYawOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.numericUpDown5.Location = new System.Drawing.Point(291, 3);
-            this.numericUpDown5.Maximum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            0});
-            this.numericUpDown5.Minimum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            -2147483648});
-            this.numericUpDown5.Name = "numericUpDown5";
-            this.numericUpDown5.Size = new System.Drawing.Size(45, 20);
-            this.numericUpDown5.TabIndex = 55;
-            this.numericUpDown5.Value = global::ALVR.Properties.Settings.Default.leftControllerYawOffset;
-            // 
-            // numericUpDown6
-            // 
-            this.numericUpDown6.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerRollOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.numericUpDown6.Location = new System.Drawing.Point(342, 3);
-            this.numericUpDown6.Maximum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            0});
-            this.numericUpDown6.Minimum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            -2147483648});
-            this.numericUpDown6.Name = "numericUpDown6";
-            this.numericUpDown6.Size = new System.Drawing.Size(45, 20);
-            this.numericUpDown6.TabIndex = 56;
-            this.numericUpDown6.Value = global::ALVR.Properties.Settings.Default.leftControllerRollOffset;
-            // 
-            // numericUpDown1
-            // 
-            this.numericUpDown1.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetX", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.numericUpDown1.DecimalPlaces = 3;
-            this.numericUpDown1.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            196608});
-            this.numericUpDown1.Location = new System.Drawing.Point(189, 3);
-            this.numericUpDown1.Maximum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            131072});
-            this.numericUpDown1.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.numericUpDown1.Name = "numericUpDown1";
-            this.numericUpDown1.Size = new System.Drawing.Size(55, 20);
-            this.numericUpDown1.TabIndex = 53;
-            this.numericUpDown1.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetX;
-            // 
-            // numericUpDown2
-            // 
-            this.numericUpDown2.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetY", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.numericUpDown2.DecimalPlaces = 3;
-            this.numericUpDown2.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            196608});
-            this.numericUpDown2.Location = new System.Drawing.Point(250, 3);
-            this.numericUpDown2.Maximum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            131072});
-            this.numericUpDown2.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.numericUpDown2.Name = "numericUpDown2";
-            this.numericUpDown2.Size = new System.Drawing.Size(55, 20);
-            this.numericUpDown2.TabIndex = 54;
-            this.numericUpDown2.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetY;
-            // 
-            // numericUpDown3
-            // 
-            this.numericUpDown3.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetZ", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.numericUpDown3.DecimalPlaces = 3;
-            this.numericUpDown3.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            196608});
-            this.numericUpDown3.Location = new System.Drawing.Point(311, 3);
-            this.numericUpDown3.Maximum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            131072});
-            this.numericUpDown3.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.numericUpDown3.Name = "numericUpDown3";
-            this.numericUpDown3.Size = new System.Drawing.Size(55, 20);
-            this.numericUpDown3.TabIndex = 55;
-            this.numericUpDown3.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetZ;
-            // 
-            // controllerPoseOffset
-            // 
-            this.controllerPoseOffset.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.controllerPoseOffset.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "controllerPoseOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.controllerPoseOffset.Location = new System.Drawing.Point(111, 6);
-            this.controllerPoseOffset.Name = "controllerPoseOffset";
-            this.controllerPoseOffset.Size = new System.Drawing.Size(52, 19);
-            this.controllerPoseOffset.TabIndex = 21;
-            this.controllerPoseOffset.Text = global::ALVR.Properties.Settings.Default.controllerPoseOffset;
-            this.controllerPoseOffset.Click += new System.EventHandler(this.controllerPoseOffset_Click);
-            // 
-            // debugLogCheckBox
-            // 
-            this.debugLogCheckBox.AutoSize = true;
-            this.debugLogCheckBox.Checked = global::ALVR.Properties.Settings.Default.debugLog;
-            this.debugLogCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "debugLog", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.debugLogCheckBox.Location = new System.Drawing.Point(3, 3);
-            this.debugLogCheckBox.Name = "debugLogCheckBox";
-            this.debugLogCheckBox.Size = new System.Drawing.Size(78, 15);
-            this.debugLogCheckBox.TabIndex = 9;
-            this.debugLogCheckBox.Text = "DebugLog";
-            this.debugLogCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // debugCaptureOutputCheckBox
-            // 
-            this.debugCaptureOutputCheckBox.AutoSize = true;
-            this.debugCaptureOutputCheckBox.Checked = global::ALVR.Properties.Settings.Default.debugCaptureOutput;
-            this.debugCaptureOutputCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "debugCaptureOutput", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.debugCaptureOutputCheckBox.Location = new System.Drawing.Point(3, 24);
-            this.debugCaptureOutputCheckBox.Name = "debugCaptureOutputCheckBox";
-            this.debugCaptureOutputCheckBox.Size = new System.Drawing.Size(138, 15);
-            this.debugCaptureOutputCheckBox.TabIndex = 9;
-            this.debugCaptureOutputCheckBox.Text = "DebugCaptureOutput";
-            this.debugCaptureOutputCheckBox.UseVisualStyleBackColor = true;
-            // 
             // Launcher
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -3186,6 +3224,44 @@
             this.tableLayoutPanel8.ResumeLayout(false);
             this.tableLayoutPanel8.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.statDataGridView)).EndInit();
+            this.presetsTab.ResumeLayout(false);
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            this.flowLayoutPanel44.ResumeLayout(false);
+            this.flowLayoutPanel42.ResumeLayout(false);
+            this.otherTab.ResumeLayout(false);
+            this.tableLayoutPanel11.ResumeLayout(false);
+            this.tableLayoutPanel11.PerformLayout();
+            this.flowLayoutPanel26.ResumeLayout(false);
+            this.flowLayoutPanel26.PerformLayout();
+            this.flowLayoutPanel35.ResumeLayout(false);
+            this.flowLayoutPanel35.PerformLayout();
+            this.flowLayoutPanel36.ResumeLayout(false);
+            this.flowLayoutPanel36.PerformLayout();
+            this.flowLayoutPanel15.ResumeLayout(false);
+            this.flowLayoutPanel15.PerformLayout();
+            this.flowLayoutPanel17.ResumeLayout(false);
+            this.flowLayoutPanel17.PerformLayout();
+            this.flowLayoutPanel24.ResumeLayout(false);
+            this.flowLayoutPanel24.PerformLayout();
+            this.flowLayoutPanel25.ResumeLayout(false);
+            this.flowLayoutPanel25.PerformLayout();
+            this.tableLayoutPanel3.ResumeLayout(false);
+            this.tableLayoutPanel3.PerformLayout();
+            this.flowLayoutPanel43.ResumeLayout(false);
+            this.flowLayoutPanel43.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown4)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown5)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown6)).EndInit();
+            this.flowLayoutPanel37.ResumeLayout(false);
+            this.flowLayoutPanel37.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).EndInit();
+            this.flowLayoutPanel38.ResumeLayout(false);
+            this.flowLayoutPanel38.PerformLayout();
+            this.flowLayoutPanel16.ResumeLayout(false);
+            this.flowLayoutPanel16.PerformLayout();
             this.videoTab.ResumeLayout(false);
             this.videoTab.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
@@ -3193,6 +3269,7 @@
             this.flowLayoutPanel39.ResumeLayout(false);
             this.flowLayoutPanel40.ResumeLayout(false);
             this.flowLayoutPanel40.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.sharpeningBox)).EndInit();
             this.flowLayoutPanel2.ResumeLayout(false);
             this.flowLayoutPanel2.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
@@ -3220,13 +3297,17 @@
             this.flowLayoutPanel32.ResumeLayout(false);
             this.flowLayoutPanel28.ResumeLayout(false);
             this.flowLayoutPanel28.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.saturationBox)).EndInit();
             this.flowLayoutPanel30.ResumeLayout(false);
             this.flowLayoutPanel30.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.contrastBox)).EndInit();
             this.flowLayoutPanel33.ResumeLayout(false);
             this.flowLayoutPanel29.ResumeLayout(false);
             this.flowLayoutPanel29.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.brightnessBox)).EndInit();
             this.flowLayoutPanel31.ResumeLayout(false);
             this.flowLayoutPanel31.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.gammaBox)).EndInit();
             this.flowLayoutPanel34.ResumeLayout(false);
             this.flowLayoutPanel34.PerformLayout();
             this.soundTab.ResumeLayout(false);
@@ -3236,37 +3317,6 @@
             this.flowLayoutPanel13.PerformLayout();
             this.flowLayoutPanel14.ResumeLayout(false);
             this.flowLayoutPanel14.PerformLayout();
-            this.otherTab.ResumeLayout(false);
-            this.tableLayoutPanel11.ResumeLayout(false);
-            this.tableLayoutPanel11.PerformLayout();
-            this.flowLayoutPanel26.ResumeLayout(false);
-            this.flowLayoutPanel26.PerformLayout();
-            this.flowLayoutPanel35.ResumeLayout(false);
-            this.flowLayoutPanel35.PerformLayout();
-            this.flowLayoutPanel36.ResumeLayout(false);
-            this.flowLayoutPanel36.PerformLayout();
-            this.flowLayoutPanel15.ResumeLayout(false);
-            this.flowLayoutPanel15.PerformLayout();
-            this.flowLayoutPanel17.ResumeLayout(false);
-            this.flowLayoutPanel17.PerformLayout();
-            this.flowLayoutPanel24.ResumeLayout(false);
-            this.flowLayoutPanel24.PerformLayout();
-            this.flowLayoutPanel25.ResumeLayout(false);
-            this.flowLayoutPanel25.PerformLayout();
-            this.tableLayoutPanel3.ResumeLayout(false);
-            this.tableLayoutPanel3.PerformLayout();
-            this.flowLayoutPanel43.ResumeLayout(false);
-            this.flowLayoutPanel43.PerformLayout();
-            this.flowLayoutPanel37.ResumeLayout(false);
-            this.flowLayoutPanel37.PerformLayout();
-            this.flowLayoutPanel38.ResumeLayout(false);
-            this.flowLayoutPanel38.PerformLayout();
-            this.flowLayoutPanel16.ResumeLayout(false);
-            this.flowLayoutPanel16.PerformLayout();
-            this.presetsTab.ResumeLayout(false);
-            this.tableLayoutPanel2.ResumeLayout(false);
-            this.tableLayoutPanel2.PerformLayout();
-            this.flowLayoutPanel42.ResumeLayout(false);
             this.debugTab.ResumeLayout(false);
             this.tableLayoutPanel14.ResumeLayout(false);
             this.tableLayoutPanel14.PerformLayout();
@@ -3285,17 +3335,6 @@
             this.flowLayoutPanel23.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.resolutionBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.sharpeningBox)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.saturationBox)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.contrastBox)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.brightnessBox)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.gammaBox)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown4)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown5)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown6)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -3518,6 +3557,9 @@
         private System.Windows.Forms.NumericUpDown numericUpDown6;
         private System.Windows.Forms.NumericUpDown numericUpDown2;
         private System.Windows.Forms.NumericUpDown numericUpDown3;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel44;
+        private MetroFramework.Controls.MetroButton fixBoneworksControllersButton;
+        private MetroFramework.Controls.MetroLabel metroLabel42;
     }
 }
 

--- a/ALVR/Launcher.Designer.cs
+++ b/ALVR/Launcher.Designer.cs
@@ -29,13 +29,13 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle15 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle16 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle17 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle18 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle19 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle20 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle21 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Launcher));
             this.sendClientDebugFlagsButton = new MetroFramework.Controls.MetroButton();
             this.sendDriverTestModeButton = new MetroFramework.Controls.MetroButton();
@@ -70,16 +70,23 @@
             this.autoConnectCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.videoTab = new MetroFramework.Controls.MetroTabPage();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel39 = new System.Windows.Forms.FlowLayoutPanel();
+            this.flowLayoutPanel40 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel37 = new MetroFramework.Controls.MetroLabel();
+            this.sharpeningBox = new System.Windows.Forms.NumericUpDown();
+            this.flowLayoutPanel41 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel31 = new MetroFramework.Controls.MetroLabel();
             this.codecHelp = new MetroFramework.Controls.MetroLabel();
             this.codecComboBox = new MetroFramework.Controls.MetroComboBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.forceNV12 = new MetroFramework.Controls.MetroCheckBox();
             this.nv12Tooltip = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel3 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel7 = new MetroFramework.Controls.MetroLabel();
             this.bitrateHelp = new MetroFramework.Controls.MetroLabel();
             this.bitrateLabel = new MetroFramework.Controls.MetroLabel();
+            this.bitrateTrackBar = new MetroFramework.Controls.MetroTrackBar();
             this.flowLayoutPanel5 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel10 = new MetroFramework.Controls.MetroLabel();
             this.resolutionHelp = new MetroFramework.Controls.MetroLabel();
@@ -92,6 +99,8 @@
             this.metroLabel19 = new MetroFramework.Controls.MetroLabel();
             this.bufferLabel = new MetroFramework.Controls.MetroLabel();
             this.bufferHelp = new MetroFramework.Controls.MetroLabel();
+            this.enableColorCorrectionCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.bufferTrackBar = new MetroFramework.Controls.MetroTrackBar();
             this.flowLayoutPanel9 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel21 = new MetroFramework.Controls.MetroLabel();
             this.ffrHelp = new MetroFramework.Controls.MetroLabel();
@@ -100,9 +109,11 @@
             this.ffrMeanLabel = new MetroFramework.Controls.MetroLabel();
             this.ffrStrengthHelp = new MetroFramework.Controls.MetroLabel();
             this.foveationStrengthLabel = new MetroFramework.Controls.MetroLabel();
+            this.foveationStrengthTrackBar = new MetroFramework.Controls.MetroTrackBar();
             this.flowLayoutPanel11 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel23 = new MetroFramework.Controls.MetroLabel();
             this.ffrVerticalOffsetHelp = new MetroFramework.Controls.MetroLabel();
+            this.foveationVerticalOffsetTrackBar = new MetroFramework.Controls.MetroTrackBar();
             this.foveationVerticalOffsetLabel = new MetroFramework.Controls.MetroLabel();
             this.panel1 = new System.Windows.Forms.Panel();
             this.metroLabel34 = new MetroFramework.Controls.MetroLabel();
@@ -118,45 +129,65 @@
             this.flowLayoutPanel32 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel28 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel33 = new MetroFramework.Controls.MetroLabel();
+            this.saturationBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel30 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel25 = new MetroFramework.Controls.MetroLabel();
+            this.contrastBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel33 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel29 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel32 = new MetroFramework.Controls.MetroLabel();
+            this.brightnessBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel31 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel24 = new MetroFramework.Controls.MetroLabel();
+            this.gammaBox = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel34 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel35 = new MetroFramework.Controls.MetroLabel();
             this.bufferOffsetLabel = new MetroFramework.Controls.MetroLabel();
             this.soundTab = new MetroFramework.Controls.MetroTabPage();
             this.tableLayoutPanel9 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel13 = new System.Windows.Forms.FlowLayoutPanel();
+            this.soundCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.noSoundDeviceLabel = new MetroFramework.Controls.MetroLabel();
             this.soundDeviceComboBox = new MetroFramework.Controls.MetroComboBox();
+            this.streamMic = new MetroFramework.Controls.MetroCheckBox();
             this.flowLayoutPanel14 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel20 = new MetroFramework.Controls.MetroLabel();
             this.metroLink1 = new MetroFramework.Controls.MetroLink();
+            this.defaultSoundDeviceCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.otherTab = new MetroFramework.Controls.MetroTabPage();
             this.tableLayoutPanel11 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel16 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel12 = new MetroFramework.Controls.MetroLabel();
+            this.controllerPoseOffset = new MetroFramework.Controls.MetroTextBox();
             this.metroButton1 = new MetroFramework.Controls.MetroButton();
             this.flowLayoutPanel26 = new System.Windows.Forms.FlowLayoutPanel();
+            this.onlySteamVRCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.flowLayoutPanel35 = new System.Windows.Forms.FlowLayoutPanel();
+            this.steamAutoLaunch = new MetroFramework.Controls.MetroCheckBox();
             this.autoLaunchHelp = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel36 = new System.Windows.Forms.FlowLayoutPanel();
+            this.launchMinimized = new MetroFramework.Controls.MetroCheckBox();
+            this.force60HzCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.suppressFrameDropCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.disableThrottlingCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.disableController = new MetroFramework.Controls.MetroCheckBox();
+            this.force3DOFCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.flowLayoutPanel15 = new System.Windows.Forms.FlowLayoutPanel();
+            this.aggressiveKeyframeResend = new MetroFramework.Controls.MetroCheckBox();
             this.aggressiveKeyframeResendHelp = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel17 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel29 = new MetroFramework.Controls.MetroLabel();
+            this.trackingFrameOffsetTextBox = new MetroFramework.Controls.MetroTextBox();
             this.saveTrackingFrameOffsetButton = new MetroFramework.Controls.MetroButton();
             this.metroLabel30 = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel24 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel27 = new MetroFramework.Controls.MetroLabel();
+            this.connectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
             this.refConnectCommandButton = new MetroFramework.Controls.MetroButton();
             this.metroLabel26 = new MetroFramework.Controls.MetroLabel();
             this.flowLayoutPanel25 = new System.Windows.Forms.FlowLayoutPanel();
             this.metroLabel28 = new MetroFramework.Controls.MetroLabel();
+            this.disconnectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
             this.refDisconnectCommandButton = new MetroFramework.Controls.MetroButton();
             this.flowLayoutPanel37 = new System.Windows.Forms.FlowLayoutPanel();
             this.flowLayoutPanel38 = new System.Windows.Forms.FlowLayoutPanel();
@@ -176,7 +207,9 @@
             this.captureLayerDDSButton = new MetroFramework.Controls.MetroButton();
             this.packetlossButton = new MetroFramework.Controls.MetroButton();
             this.flowLayoutPanel21 = new System.Windows.Forms.FlowLayoutPanel();
+            this.debugLogCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.metroCheckBox1 = new MetroFramework.Controls.MetroCheckBox();
+            this.debugCaptureOutputCheckBox = new MetroFramework.Controls.MetroCheckBox();
             this.metroCheckBox2 = new MetroFramework.Controls.MetroCheckBox();
             this.metroCheckBox3 = new MetroFramework.Controls.MetroCheckBox();
             this.metroButton5 = new MetroFramework.Controls.MetroButton();
@@ -201,39 +234,11 @@
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
             this.notifyIcon1 = new System.Windows.Forms.NotifyIcon(this.components);
-            this.flowLayoutPanel39 = new System.Windows.Forms.FlowLayoutPanel();
-            this.flowLayoutPanel40 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel37 = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel41 = new System.Windows.Forms.FlowLayoutPanel();
-            this.soundCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.streamMic = new MetroFramework.Controls.MetroCheckBox();
-            this.defaultSoundDeviceCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.sharpeningBox = new System.Windows.Forms.NumericUpDown();
-            this.forceNV12 = new MetroFramework.Controls.MetroCheckBox();
-            this.bitrateTrackBar = new MetroFramework.Controls.MetroTrackBar();
-            this.enableColorCorrectionCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.bufferTrackBar = new MetroFramework.Controls.MetroTrackBar();
-            this.foveationStrengthTrackBar = new MetroFramework.Controls.MetroTrackBar();
-            this.foveationVerticalOffsetTrackBar = new MetroFramework.Controls.MetroTrackBar();
-            this.saturationBox = new System.Windows.Forms.NumericUpDown();
-            this.contrastBox = new System.Windows.Forms.NumericUpDown();
-            this.brightnessBox = new System.Windows.Forms.NumericUpDown();
-            this.gammaBox = new System.Windows.Forms.NumericUpDown();
-            this.controllerPoseOffset = new MetroFramework.Controls.MetroTextBox();
-            this.onlySteamVRCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.steamAutoLaunch = new MetroFramework.Controls.MetroCheckBox();
-            this.launchMinimized = new MetroFramework.Controls.MetroCheckBox();
-            this.force60HzCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.suppressFrameDropCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.disableThrottlingCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.disableController = new MetroFramework.Controls.MetroCheckBox();
-            this.force3DOFCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.aggressiveKeyframeResend = new MetroFramework.Controls.MetroCheckBox();
-            this.trackingFrameOffsetTextBox = new MetroFramework.Controls.MetroTextBox();
-            this.connectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
-            this.disconnectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
-            this.debugLogCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.debugCaptureOutputCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.presetsTab = new MetroFramework.Controls.MetroTabPage();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.revertToDefaultButton = new MetroFramework.Controls.MetroButton();
+            this.flowLayoutPanel42 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel38 = new MetroFramework.Controls.MetroLabel();
             this.metroTabControl1.SuspendLayout();
             this.serverTab.SuspendLayout();
             this.findingPanel.SuspendLayout();
@@ -248,6 +253,9 @@
             ((System.ComponentModel.ISupportInitialize)(this.statDataGridView)).BeginInit();
             this.videoTab.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
+            this.flowLayoutPanel39.SuspendLayout();
+            this.flowLayoutPanel40.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.sharpeningBox)).BeginInit();
             this.flowLayoutPanel2.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel3.SuspendLayout();
@@ -262,10 +270,14 @@
             this.flowLayoutPanel27.SuspendLayout();
             this.flowLayoutPanel32.SuspendLayout();
             this.flowLayoutPanel28.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.saturationBox)).BeginInit();
             this.flowLayoutPanel30.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.contrastBox)).BeginInit();
             this.flowLayoutPanel33.SuspendLayout();
             this.flowLayoutPanel29.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.brightnessBox)).BeginInit();
             this.flowLayoutPanel31.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.gammaBox)).BeginInit();
             this.flowLayoutPanel34.SuspendLayout();
             this.soundTab.SuspendLayout();
             this.tableLayoutPanel9.SuspendLayout();
@@ -295,13 +307,9 @@
             this.flowLayoutPanel23.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.resolutionBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            this.flowLayoutPanel39.SuspendLayout();
-            this.flowLayoutPanel40.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.sharpeningBox)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.saturationBox)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.contrastBox)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.brightnessBox)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.gammaBox)).BeginInit();
+            this.presetsTab.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            this.flowLayoutPanel42.SuspendLayout();
             this.SuspendLayout();
             // 
             // sendClientDebugFlagsButton
@@ -346,12 +354,13 @@
             this.metroTabControl1.Controls.Add(this.videoTab);
             this.metroTabControl1.Controls.Add(this.soundTab);
             this.metroTabControl1.Controls.Add(this.otherTab);
+            this.metroTabControl1.Controls.Add(this.presetsTab);
             this.metroTabControl1.Controls.Add(this.debugTab);
             this.metroTabControl1.Controls.Add(this.aboutTab);
             this.metroTabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.metroTabControl1.Location = new System.Drawing.Point(20, 65);
             this.metroTabControl1.Name = "metroTabControl1";
-            this.metroTabControl1.SelectedIndex = 1;
+            this.metroTabControl1.SelectedIndex = 4;
             this.metroTabControl1.Size = new System.Drawing.Size(663, 456);
             this.metroTabControl1.TabIndex = 8;
             // 
@@ -417,14 +426,14 @@
             this.dataGridView1.AllowUserToResizeRows = false;
             this.dataGridView1.BackgroundColor = System.Drawing.Color.White;
             this.dataGridView1.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridView1.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle15.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle15.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle15.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            dataGridViewCellStyle15.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle15.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle15.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle15.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataGridView1.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle15;
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView1.ColumnHeadersVisible = false;
             this.dataGridView1.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
@@ -433,32 +442,32 @@
             this.refreshRateColumn,
             this.Button});
             this.tableLayoutPanel7.SetColumnSpan(this.dataGridView1, 3);
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dataGridView1.DefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle16.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle16.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle16.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            dataGridViewCellStyle16.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle16.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle16.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle16.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.dataGridView1.DefaultCellStyle = dataGridViewCellStyle16;
             this.dataGridView1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dataGridView1.Location = new System.Drawing.Point(3, 108);
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.ReadOnly = true;
-            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridView1.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
+            dataGridViewCellStyle17.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle17.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle17.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            dataGridViewCellStyle17.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle17.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle17.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle17.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataGridView1.RowHeadersDefaultCellStyle = dataGridViewCellStyle17;
             this.dataGridView1.RowHeadersVisible = false;
             this.dataGridView1.RowHeadersWidth = 51;
-            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.Color.White;
-            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.Color.Black;
-            this.dataGridView1.RowsDefaultCellStyle = dataGridViewCellStyle4;
+            dataGridViewCellStyle18.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle18.SelectionBackColor = System.Drawing.Color.White;
+            dataGridViewCellStyle18.SelectionForeColor = System.Drawing.Color.Black;
+            this.dataGridView1.RowsDefaultCellStyle = dataGridViewCellStyle18;
             this.dataGridView1.RowTemplate.DefaultCellStyle.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(192)))), ((int)(((byte)(192)))));
             this.dataGridView1.RowTemplate.Height = 40;
             this.dataGridView1.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
@@ -669,39 +678,39 @@
             this.statDataGridView.AllowUserToDeleteRows = false;
             this.statDataGridView.BackgroundColor = System.Drawing.Color.White;
             this.statDataGridView.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
-            dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle5.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            dataGridViewCellStyle5.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.statDataGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle5;
+            dataGridViewCellStyle19.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle19.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle19.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            dataGridViewCellStyle19.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle19.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle19.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle19.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.statDataGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle19;
             this.statDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.statDataGridView.ColumnHeadersVisible = false;
             this.statDataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Name1,
             this.Value1});
-            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle6.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            dataGridViewCellStyle6.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle6.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle6.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.statDataGridView.DefaultCellStyle = dataGridViewCellStyle6;
+            dataGridViewCellStyle20.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle20.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle20.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            dataGridViewCellStyle20.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle20.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle20.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle20.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.statDataGridView.DefaultCellStyle = dataGridViewCellStyle20;
             this.statDataGridView.Dock = System.Windows.Forms.DockStyle.Fill;
             this.statDataGridView.Location = new System.Drawing.Point(308, 13);
             this.statDataGridView.Name = "statDataGridView";
             this.statDataGridView.ReadOnly = true;
-            dataGridViewCellStyle7.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle7.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle7.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
-            dataGridViewCellStyle7.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle7.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle7.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle7.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.statDataGridView.RowHeadersDefaultCellStyle = dataGridViewCellStyle7;
+            dataGridViewCellStyle21.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle21.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle21.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            dataGridViewCellStyle21.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle21.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle21.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle21.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.statDataGridView.RowHeadersDefaultCellStyle = dataGridViewCellStyle21;
             this.statDataGridView.RowHeadersVisible = false;
             this.statDataGridView.RowHeadersWidth = 51;
             this.tableLayoutPanel8.SetRowSpan(this.statDataGridView, 3);
@@ -846,6 +855,74 @@
             this.tableLayoutPanel1.TabIndex = 38;
             this.tableLayoutPanel1.Paint += new System.Windows.Forms.PaintEventHandler(this.tableLayoutPanel1_Paint);
             // 
+            // flowLayoutPanel39
+            // 
+            this.flowLayoutPanel39.AutoSize = true;
+            this.flowLayoutPanel39.Controls.Add(this.flowLayoutPanel40);
+            this.flowLayoutPanel39.Controls.Add(this.flowLayoutPanel41);
+            this.flowLayoutPanel39.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel39.Location = new System.Drawing.Point(230, 372);
+            this.flowLayoutPanel39.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel39.Name = "flowLayoutPanel39";
+            this.flowLayoutPanel39.Size = new System.Drawing.Size(275, 29);
+            this.flowLayoutPanel39.TabIndex = 60;
+            this.flowLayoutPanel39.WrapContents = false;
+            // 
+            // flowLayoutPanel40
+            // 
+            this.flowLayoutPanel40.Controls.Add(this.metroLabel37);
+            this.flowLayoutPanel40.Controls.Add(this.sharpeningBox);
+            this.flowLayoutPanel40.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel40.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel40.Name = "flowLayoutPanel40";
+            this.flowLayoutPanel40.Size = new System.Drawing.Size(128, 29);
+            this.flowLayoutPanel40.TabIndex = 54;
+            this.flowLayoutPanel40.WrapContents = false;
+            // 
+            // metroLabel37
+            // 
+            this.metroLabel37.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel37.AutoSize = true;
+            this.metroLabel37.Location = new System.Drawing.Point(2, 3);
+            this.metroLabel37.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.metroLabel37.Name = "metroLabel37";
+            this.metroLabel37.Size = new System.Drawing.Size(75, 19);
+            this.metroLabel37.TabIndex = 45;
+            this.metroLabel37.Text = "Sharpening";
+            // 
+            // sharpeningBox
+            // 
+            this.sharpeningBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "sharpening", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.sharpeningBox.DecimalPlaces = 2;
+            this.sharpeningBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.sharpeningBox.Location = new System.Drawing.Point(82, 3);
+            this.sharpeningBox.Maximum = new decimal(new int[] {
+            500,
+            0,
+            0,
+            131072});
+            this.sharpeningBox.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.sharpeningBox.Name = "sharpeningBox";
+            this.sharpeningBox.Size = new System.Drawing.Size(44, 20);
+            this.sharpeningBox.TabIndex = 44;
+            this.sharpeningBox.Value = global::ALVR.Properties.Settings.Default.sharpening;
+            // 
+            // flowLayoutPanel41
+            // 
+            this.flowLayoutPanel41.Location = new System.Drawing.Point(128, 0);
+            this.flowLayoutPanel41.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel41.Name = "flowLayoutPanel41";
+            this.flowLayoutPanel41.Size = new System.Drawing.Size(146, 29);
+            this.flowLayoutPanel41.TabIndex = 56;
+            // 
             // flowLayoutPanel2
             // 
             this.flowLayoutPanel2.Anchor = System.Windows.Forms.AnchorStyles.Right;
@@ -903,6 +980,20 @@
             this.flowLayoutPanel1.Size = new System.Drawing.Size(136, 21);
             this.flowLayoutPanel1.TabIndex = 38;
             // 
+            // forceNV12
+            // 
+            this.forceNV12.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.forceNV12.AutoSize = true;
+            this.forceNV12.Checked = global::ALVR.Properties.Settings.Default.nv12;
+            this.forceNV12.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "nv12", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.forceNV12.Location = new System.Drawing.Point(3, 3);
+            this.forceNV12.Margin = new System.Windows.Forms.Padding(3, 3, 0, 3);
+            this.forceNV12.Name = "forceNV12";
+            this.forceNV12.Size = new System.Drawing.Size(115, 15);
+            this.forceNV12.TabIndex = 35;
+            this.forceNV12.Text = "use custom NV12";
+            this.forceNV12.UseVisualStyleBackColor = true;
+            // 
             // nv12Tooltip
             // 
             this.nv12Tooltip.AutoSize = true;
@@ -958,6 +1049,22 @@
             this.bitrateLabel.Size = new System.Drawing.Size(60, 19);
             this.bitrateLabel.TabIndex = 5;
             this.bitrateLabel.Text = "30Mbps";
+            // 
+            // bitrateTrackBar
+            // 
+            this.bitrateTrackBar.BackColor = System.Drawing.Color.Transparent;
+            this.bitrateTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "bitrate", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.bitrateTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.bitrateTrackBar.Location = new System.Drawing.Point(233, 73);
+            this.bitrateTrackBar.Maximum = 250;
+            this.bitrateTrackBar.Minimum = 1;
+            this.bitrateTrackBar.Name = "bitrateTrackBar";
+            this.bitrateTrackBar.Size = new System.Drawing.Size(269, 25);
+            this.bitrateTrackBar.TabIndex = 2;
+            this.bitrateTrackBar.Text = "metroTrackBar1";
+            this.bitrateTrackBar.Value = global::ALVR.Properties.Settings.Default.bitrate;
+            this.bitrateTrackBar.ValueChanged += new System.EventHandler(this.bitrateTrackBar_ValueChanged);
+            this.bitrateTrackBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.bitrateTrackBar_Scroll);
             // 
             // flowLayoutPanel5
             // 
@@ -1106,6 +1213,33 @@
             this.bufferHelp.Text = "?";
             this.bufferHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
+            // enableColorCorrectionCheckBox
+            // 
+            this.enableColorCorrectionCheckBox.AutoSize = true;
+            this.enableColorCorrectionCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableColorCorrection;
+            this.enableColorCorrectionCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableColorCorrection", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.enableColorCorrectionCheckBox.Location = new System.Drawing.Point(233, 295);
+            this.enableColorCorrectionCheckBox.Name = "enableColorCorrectionCheckBox";
+            this.enableColorCorrectionCheckBox.Size = new System.Drawing.Size(58, 15);
+            this.enableColorCorrectionCheckBox.TabIndex = 40;
+            this.enableColorCorrectionCheckBox.Text = "Enable";
+            this.enableColorCorrectionCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // bufferTrackBar
+            // 
+            this.bufferTrackBar.BackColor = System.Drawing.Color.Transparent;
+            this.bufferTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "bufferOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.bufferTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.bufferTrackBar.Location = new System.Drawing.Point(233, 160);
+            this.bufferTrackBar.Minimum = -100;
+            this.bufferTrackBar.Name = "bufferTrackBar";
+            this.bufferTrackBar.Size = new System.Drawing.Size(269, 20);
+            this.bufferTrackBar.TabIndex = 2;
+            this.bufferTrackBar.Text = "metroTrackBar1";
+            this.bufferTrackBar.Value = global::ALVR.Properties.Settings.Default.bufferOffset;
+            this.bufferTrackBar.ValueChanged += new System.EventHandler(this.bufferTrackBar_ValueChanged);
+            this.bufferTrackBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.bufferTrackBar_Scroll);
+            // 
             // flowLayoutPanel9
             // 
             this.flowLayoutPanel9.Anchor = System.Windows.Forms.AnchorStyles.Right;
@@ -1204,6 +1338,23 @@
             this.foveationStrengthLabel.Text = "2";
             this.foveationStrengthLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
+            // foveationStrengthTrackBar
+            // 
+            this.foveationStrengthTrackBar.BackColor = System.Drawing.Color.Transparent;
+            this.foveationStrengthTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "foveationStrength", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.foveationStrengthTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.foveationStrengthTrackBar.LargeChange = 100;
+            this.foveationStrengthTrackBar.Location = new System.Drawing.Point(233, 240);
+            this.foveationStrengthTrackBar.Maximum = 500;
+            this.foveationStrengthTrackBar.MaximumSize = new System.Drawing.Size(0, 14);
+            this.foveationStrengthTrackBar.Name = "foveationStrengthTrackBar";
+            this.foveationStrengthTrackBar.Size = new System.Drawing.Size(269, 10);
+            this.foveationStrengthTrackBar.SmallChange = 10;
+            this.foveationStrengthTrackBar.TabIndex = 30;
+            this.foveationStrengthTrackBar.Text = "metroTrackBar1";
+            this.foveationStrengthTrackBar.Value = global::ALVR.Properties.Settings.Default.foveationStrength;
+            this.foveationStrengthTrackBar.ValueChanged += new System.EventHandler(this.FoveationStrengthTrackBar_ValueChanged);
+            // 
             // flowLayoutPanel11
             // 
             this.flowLayoutPanel11.AutoSize = true;
@@ -1237,6 +1388,23 @@
             this.ffrVerticalOffsetHelp.TabIndex = 32;
             this.ffrVerticalOffsetHelp.Text = "?";
             this.ffrVerticalOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // foveationVerticalOffsetTrackBar
+            // 
+            this.foveationVerticalOffsetTrackBar.BackColor = System.Drawing.Color.Transparent;
+            this.foveationVerticalOffsetTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "foveationVerticalOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.foveationVerticalOffsetTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.foveationVerticalOffsetTrackBar.LargeChange = 2;
+            this.foveationVerticalOffsetTrackBar.Location = new System.Drawing.Point(233, 275);
+            this.foveationVerticalOffsetTrackBar.Maximum = 10;
+            this.foveationVerticalOffsetTrackBar.Minimum = -10;
+            this.foveationVerticalOffsetTrackBar.MouseWheelBarPartitions = 1;
+            this.foveationVerticalOffsetTrackBar.Name = "foveationVerticalOffsetTrackBar";
+            this.foveationVerticalOffsetTrackBar.Size = new System.Drawing.Size(269, 14);
+            this.foveationVerticalOffsetTrackBar.TabIndex = 34;
+            this.foveationVerticalOffsetTrackBar.Text = "metroTrackBar1";
+            this.foveationVerticalOffsetTrackBar.Value = global::ALVR.Properties.Settings.Default.foveationVerticalOffset;
+            this.foveationVerticalOffsetTrackBar.ValueChanged += new System.EventHandler(this.FoveationVerticalOffsetTrackBar_ValueChanged);
             // 
             // foveationVerticalOffsetLabel
             // 
@@ -1403,6 +1571,31 @@
             this.metroLabel33.TabIndex = 47;
             this.metroLabel33.Text = "Saturation";
             // 
+            // saturationBox
+            // 
+            this.saturationBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "saturation", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.saturationBox.DecimalPlaces = 2;
+            this.saturationBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.saturationBox.Location = new System.Drawing.Point(75, 3);
+            this.saturationBox.Maximum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.saturationBox.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            -2147483648});
+            this.saturationBox.Name = "saturationBox";
+            this.saturationBox.Size = new System.Drawing.Size(46, 20);
+            this.saturationBox.TabIndex = 48;
+            this.saturationBox.Value = global::ALVR.Properties.Settings.Default.saturation;
+            // 
             // flowLayoutPanel30
             // 
             this.flowLayoutPanel30.Controls.Add(this.metroLabel25);
@@ -1423,6 +1616,31 @@
             this.metroLabel25.Size = new System.Drawing.Size(58, 19);
             this.metroLabel25.TabIndex = 43;
             this.metroLabel25.Text = "Contrast";
+            // 
+            // contrastBox
+            // 
+            this.contrastBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "contrast", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.contrastBox.DecimalPlaces = 2;
+            this.contrastBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.contrastBox.Location = new System.Drawing.Point(65, 3);
+            this.contrastBox.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.contrastBox.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.contrastBox.Name = "contrastBox";
+            this.contrastBox.Size = new System.Drawing.Size(45, 20);
+            this.contrastBox.TabIndex = 46;
+            this.contrastBox.Value = global::ALVR.Properties.Settings.Default.contrast;
             // 
             // flowLayoutPanel33
             // 
@@ -1459,6 +1677,31 @@
             this.metroLabel32.TabIndex = 45;
             this.metroLabel32.Text = "Brightness";
             // 
+            // brightnessBox
+            // 
+            this.brightnessBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "brightness", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.brightnessBox.DecimalPlaces = 2;
+            this.brightnessBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.brightnessBox.Location = new System.Drawing.Point(75, 3);
+            this.brightnessBox.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.brightnessBox.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.brightnessBox.Name = "brightnessBox";
+            this.brightnessBox.Size = new System.Drawing.Size(44, 20);
+            this.brightnessBox.TabIndex = 44;
+            this.brightnessBox.Value = global::ALVR.Properties.Settings.Default.brightness;
+            // 
             // flowLayoutPanel31
             // 
             this.flowLayoutPanel31.Controls.Add(this.metroLabel24);
@@ -1479,6 +1722,26 @@
             this.metroLabel24.Size = new System.Drawing.Size(56, 19);
             this.metroLabel24.TabIndex = 41;
             this.metroLabel24.Text = "Gamma";
+            // 
+            // gammaBox
+            // 
+            this.gammaBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "gamma", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.gammaBox.DecimalPlaces = 2;
+            this.gammaBox.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            131072});
+            this.gammaBox.Location = new System.Drawing.Point(63, 3);
+            this.gammaBox.Maximum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.gammaBox.Name = "gammaBox";
+            this.gammaBox.Size = new System.Drawing.Size(45, 20);
+            this.gammaBox.TabIndex = 42;
+            this.gammaBox.Value = global::ALVR.Properties.Settings.Default.gamma;
             // 
             // flowLayoutPanel34
             // 
@@ -1559,6 +1822,20 @@
             this.flowLayoutPanel13.TabIndex = 0;
             this.flowLayoutPanel13.WrapContents = false;
             // 
+            // soundCheckBox
+            // 
+            this.soundCheckBox.AutoSize = true;
+            this.soundCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableSound;
+            this.soundCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.soundCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableSound", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.soundCheckBox.Location = new System.Drawing.Point(3, 3);
+            this.soundCheckBox.Name = "soundCheckBox";
+            this.soundCheckBox.Size = new System.Drawing.Size(92, 15);
+            this.soundCheckBox.TabIndex = 2;
+            this.soundCheckBox.Text = "Steam sound";
+            this.soundCheckBox.UseVisualStyleBackColor = true;
+            this.soundCheckBox.CheckedChanged += new System.EventHandler(this.soundCheckBox_CheckedChanged);
+            // 
             // noSoundDeviceLabel
             // 
             this.noSoundDeviceLabel.AutoSize = true;
@@ -1578,6 +1855,20 @@
             this.soundDeviceComboBox.Name = "soundDeviceComboBox";
             this.soundDeviceComboBox.Size = new System.Drawing.Size(469, 29);
             this.soundDeviceComboBox.TabIndex = 3;
+            // 
+            // streamMic
+            // 
+            this.streamMic.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.streamMic.AutoSize = true;
+            this.streamMic.Checked = global::ALVR.Properties.Settings.Default.streamMic;
+            this.streamMic.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "streamMic", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.streamMic.Location = new System.Drawing.Point(3, 73);
+            this.streamMic.Name = "streamMic";
+            this.streamMic.Size = new System.Drawing.Size(162, 15);
+            this.streamMic.TabIndex = 5;
+            this.streamMic.Text = "Stream Quest Microphone";
+            this.streamMic.UseVisualStyleBackColor = true;
+            this.streamMic.CheckedChanged += new System.EventHandler(this.metroCheckBox4_CheckedChanged);
             // 
             // flowLayoutPanel14
             // 
@@ -1612,6 +1903,22 @@
             this.metroLink1.TabIndex = 6;
             this.metroLink1.Text = " https://www.vb-audio.com/Cable/";
             this.metroLink1.Click += new System.EventHandler(this.metroLink1_Click);
+            // 
+            // defaultSoundDeviceCheckBox
+            // 
+            this.defaultSoundDeviceCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.defaultSoundDeviceCheckBox.AutoSize = true;
+            this.defaultSoundDeviceCheckBox.Checked = global::ALVR.Properties.Settings.Default.useDefaultSoundDevice;
+            this.defaultSoundDeviceCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.defaultSoundDeviceCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "useDefaultSoundDevice", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.defaultSoundDeviceCheckBox.Location = new System.Drawing.Point(20, 41);
+            this.defaultSoundDeviceCheckBox.Margin = new System.Windows.Forms.Padding(20, 3, 3, 3);
+            this.defaultSoundDeviceCheckBox.Name = "defaultSoundDeviceCheckBox";
+            this.defaultSoundDeviceCheckBox.Size = new System.Drawing.Size(119, 15);
+            this.defaultSoundDeviceCheckBox.TabIndex = 2;
+            this.defaultSoundDeviceCheckBox.Text = "Use default device";
+            this.defaultSoundDeviceCheckBox.UseVisualStyleBackColor = true;
+            this.defaultSoundDeviceCheckBox.CheckedChanged += new System.EventHandler(this.defaultSoundDeviceCheckBox_CheckedChanged);
             // 
             // otherTab
             // 
@@ -1681,6 +1988,17 @@
             this.metroLabel12.Text = "Controller Pose Offset";
             this.metroLabel12.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
+            // controllerPoseOffset
+            // 
+            this.controllerPoseOffset.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.controllerPoseOffset.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "controllerPoseOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.controllerPoseOffset.Location = new System.Drawing.Point(147, 6);
+            this.controllerPoseOffset.Name = "controllerPoseOffset";
+            this.controllerPoseOffset.Size = new System.Drawing.Size(52, 19);
+            this.controllerPoseOffset.TabIndex = 21;
+            this.controllerPoseOffset.Text = global::ALVR.Properties.Settings.Default.controllerPoseOffset;
+            this.controllerPoseOffset.Click += new System.EventHandler(this.controllerPoseOffset_Click);
+            // 
             // metroButton1
             // 
             this.metroButton1.Anchor = System.Windows.Forms.AnchorStyles.Left;
@@ -1711,6 +2029,19 @@
             this.flowLayoutPanel26.TabIndex = 40;
             this.flowLayoutPanel26.WrapContents = false;
             // 
+            // onlySteamVRCheckBox
+            // 
+            this.onlySteamVRCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.onlySteamVRCheckBox.AutoSize = true;
+            this.onlySteamVRCheckBox.Checked = global::ALVR.Properties.Settings.Default.onlySteamVR;
+            this.onlySteamVRCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "onlySteamVR", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.onlySteamVRCheckBox.Location = new System.Drawing.Point(53, 3);
+            this.onlySteamVRCheckBox.Name = "onlySteamVRCheckBox";
+            this.onlySteamVRCheckBox.Size = new System.Drawing.Size(221, 15);
+            this.onlySteamVRCheckBox.TabIndex = 29;
+            this.onlySteamVRCheckBox.Text = "Launch only SteamVR without Steam.";
+            this.onlySteamVRCheckBox.UseVisualStyleBackColor = true;
+            // 
             // flowLayoutPanel35
             // 
             this.flowLayoutPanel35.AutoSize = true;
@@ -1721,6 +2052,18 @@
             this.flowLayoutPanel35.Name = "flowLayoutPanel35";
             this.flowLayoutPanel35.Size = new System.Drawing.Size(212, 40);
             this.flowLayoutPanel35.TabIndex = 37;
+            // 
+            // steamAutoLaunch
+            // 
+            this.steamAutoLaunch.AutoSize = true;
+            this.steamAutoLaunch.Checked = global::ALVR.Properties.Settings.Default.steamAutolaunch;
+            this.steamAutoLaunch.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "steamAutolaunch", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.steamAutoLaunch.Location = new System.Drawing.Point(3, 3);
+            this.steamAutoLaunch.Name = "steamAutoLaunch";
+            this.steamAutoLaunch.Size = new System.Drawing.Size(206, 15);
+            this.steamAutoLaunch.TabIndex = 36;
+            this.steamAutoLaunch.Text = "Launch SteamVR on HMD connect";
+            this.steamAutoLaunch.UseVisualStyleBackColor = true;
             // 
             // autoLaunchHelp
             // 
@@ -1742,6 +2085,84 @@
             this.flowLayoutPanel36.Size = new System.Drawing.Size(157, 21);
             this.flowLayoutPanel36.TabIndex = 38;
             // 
+            // launchMinimized
+            // 
+            this.launchMinimized.AutoSize = true;
+            this.launchMinimized.Checked = global::ALVR.Properties.Settings.Default.launchMinimized;
+            this.launchMinimized.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "launchMinimized", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.launchMinimized.Location = new System.Drawing.Point(3, 3);
+            this.launchMinimized.Name = "launchMinimized";
+            this.launchMinimized.Size = new System.Drawing.Size(151, 15);
+            this.launchMinimized.TabIndex = 0;
+            this.launchMinimized.Text = "Launch ALVR minimized";
+            this.launchMinimized.UseVisualStyleBackColor = true;
+            // 
+            // force60HzCheckBox
+            // 
+            this.force60HzCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.force60HzCheckBox.AutoSize = true;
+            this.force60HzCheckBox.Checked = global::ALVR.Properties.Settings.Default.force60Hz;
+            this.force60HzCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force60Hz", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.force60HzCheckBox.Location = new System.Drawing.Point(53, 85);
+            this.force60HzCheckBox.Name = "force60HzCheckBox";
+            this.force60HzCheckBox.Size = new System.Drawing.Size(81, 15);
+            this.force60HzCheckBox.TabIndex = 31;
+            this.force60HzCheckBox.Text = "Force 60Hz";
+            this.force60HzCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // suppressFrameDropCheckBox
+            // 
+            this.suppressFrameDropCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.suppressFrameDropCheckBox.AutoSize = true;
+            this.suppressFrameDropCheckBox.Checked = global::ALVR.Properties.Settings.Default.suppressFrameDrop;
+            this.suppressFrameDropCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "suppressFrameDrop", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.suppressFrameDropCheckBox.Location = new System.Drawing.Point(53, 106);
+            this.suppressFrameDropCheckBox.Name = "suppressFrameDropCheckBox";
+            this.suppressFrameDropCheckBox.Size = new System.Drawing.Size(132, 15);
+            this.suppressFrameDropCheckBox.TabIndex = 30;
+            this.suppressFrameDropCheckBox.Text = "Suppress frame drop";
+            this.suppressFrameDropCheckBox.UseVisualStyleBackColor = true;
+            this.suppressFrameDropCheckBox.CheckedChanged += new System.EventHandler(this.suppressFrameDropCheckBox_CheckedChanged);
+            // 
+            // disableThrottlingCheckBox
+            // 
+            this.disableThrottlingCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.disableThrottlingCheckBox.AutoSize = true;
+            this.disableThrottlingCheckBox.Checked = global::ALVR.Properties.Settings.Default.disableThrottling;
+            this.disableThrottlingCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableThrottling", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.disableThrottlingCheckBox.Location = new System.Drawing.Point(53, 127);
+            this.disableThrottlingCheckBox.Name = "disableThrottlingCheckBox";
+            this.disableThrottlingCheckBox.Size = new System.Drawing.Size(142, 15);
+            this.disableThrottlingCheckBox.TabIndex = 32;
+            this.disableThrottlingCheckBox.Text = "Disable send throttling";
+            this.disableThrottlingCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // disableController
+            // 
+            this.disableController.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.disableController.AutoSize = true;
+            this.disableController.Checked = global::ALVR.Properties.Settings.Default.disableController;
+            this.disableController.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableController", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.disableController.Location = new System.Drawing.Point(53, 148);
+            this.disableController.Name = "disableController";
+            this.disableController.Size = new System.Drawing.Size(115, 15);
+            this.disableController.TabIndex = 33;
+            this.disableController.Text = "Disable controller";
+            this.disableController.UseVisualStyleBackColor = true;
+            // 
+            // force3DOFCheckBox
+            // 
+            this.force3DOFCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.force3DOFCheckBox.AutoSize = true;
+            this.force3DOFCheckBox.Checked = global::ALVR.Properties.Settings.Default.force3DOF;
+            this.force3DOFCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force3DOF", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.force3DOFCheckBox.Location = new System.Drawing.Point(53, 169);
+            this.force3DOFCheckBox.Name = "force3DOFCheckBox";
+            this.force3DOFCheckBox.Size = new System.Drawing.Size(84, 15);
+            this.force3DOFCheckBox.TabIndex = 34;
+            this.force3DOFCheckBox.Text = "Force 3DOF";
+            this.force3DOFCheckBox.UseVisualStyleBackColor = true;
+            // 
             // flowLayoutPanel15
             // 
             this.flowLayoutPanel15.AutoSize = true;
@@ -1752,6 +2173,19 @@
             this.flowLayoutPanel15.Name = "flowLayoutPanel15";
             this.flowLayoutPanel15.Size = new System.Drawing.Size(194, 21);
             this.flowLayoutPanel15.TabIndex = 35;
+            // 
+            // aggressiveKeyframeResend
+            // 
+            this.aggressiveKeyframeResend.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.aggressiveKeyframeResend.AutoSize = true;
+            this.aggressiveKeyframeResend.Checked = global::ALVR.Properties.Settings.Default.aggressiveKeyframeResend;
+            this.aggressiveKeyframeResend.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "aggressiveKeyframeResend", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.aggressiveKeyframeResend.Location = new System.Drawing.Point(3, 3);
+            this.aggressiveKeyframeResend.Name = "aggressiveKeyframeResend";
+            this.aggressiveKeyframeResend.Size = new System.Drawing.Size(170, 15);
+            this.aggressiveKeyframeResend.TabIndex = 35;
+            this.aggressiveKeyframeResend.Text = "Aggressive keyframe resend";
+            this.aggressiveKeyframeResend.UseVisualStyleBackColor = true;
             // 
             // aggressiveKeyframeResendHelp
             // 
@@ -1787,6 +2221,16 @@
             this.metroLabel29.Size = new System.Drawing.Size(129, 19);
             this.metroLabel29.TabIndex = 18;
             this.metroLabel29.Text = "TrackingFrameOffset";
+            // 
+            // trackingFrameOffsetTextBox
+            // 
+            this.trackingFrameOffsetTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.trackingFrameOffsetTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "trackingFrameOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.trackingFrameOffsetTextBox.Location = new System.Drawing.Point(138, 3);
+            this.trackingFrameOffsetTextBox.Name = "trackingFrameOffsetTextBox";
+            this.trackingFrameOffsetTextBox.Size = new System.Drawing.Size(102, 25);
+            this.trackingFrameOffsetTextBox.TabIndex = 27;
+            this.trackingFrameOffsetTextBox.Text = global::ALVR.Properties.Settings.Default.trackingFrameOffset;
             // 
             // saveTrackingFrameOffsetButton
             // 
@@ -1832,6 +2276,15 @@
             this.metroLabel27.TabIndex = 17;
             this.metroLabel27.Text = "On connect";
             // 
+            // connectCommandTextBox
+            // 
+            this.connectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "connectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.connectCommandTextBox.Location = new System.Drawing.Point(85, 3);
+            this.connectCommandTextBox.Name = "connectCommandTextBox";
+            this.connectCommandTextBox.Size = new System.Drawing.Size(351, 25);
+            this.connectCommandTextBox.TabIndex = 23;
+            this.connectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.connectCommand;
+            // 
             // refConnectCommandButton
             // 
             this.refConnectCommandButton.Location = new System.Drawing.Point(442, 3);
@@ -1874,6 +2327,15 @@
             this.metroLabel28.Size = new System.Drawing.Size(92, 19);
             this.metroLabel28.TabIndex = 17;
             this.metroLabel28.Text = "On disconnect";
+            // 
+            // disconnectCommandTextBox
+            // 
+            this.disconnectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "disconnectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.disconnectCommandTextBox.Location = new System.Drawing.Point(101, 3);
+            this.disconnectCommandTextBox.Name = "disconnectCommandTextBox";
+            this.disconnectCommandTextBox.Size = new System.Drawing.Size(383, 25);
+            this.disconnectCommandTextBox.TabIndex = 25;
+            this.disconnectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.disconnectCommand;
             // 
             // refDisconnectCommandButton
             // 
@@ -2086,6 +2548,18 @@
             this.flowLayoutPanel21.Size = new System.Drawing.Size(349, 209);
             this.flowLayoutPanel21.TabIndex = 15;
             // 
+            // debugLogCheckBox
+            // 
+            this.debugLogCheckBox.AutoSize = true;
+            this.debugLogCheckBox.Checked = global::ALVR.Properties.Settings.Default.debugLog;
+            this.debugLogCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "debugLog", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.debugLogCheckBox.Location = new System.Drawing.Point(3, 3);
+            this.debugLogCheckBox.Name = "debugLogCheckBox";
+            this.debugLogCheckBox.Size = new System.Drawing.Size(78, 15);
+            this.debugLogCheckBox.TabIndex = 9;
+            this.debugLogCheckBox.Text = "DebugLog";
+            this.debugLogCheckBox.UseVisualStyleBackColor = true;
+            // 
             // metroCheckBox1
             // 
             this.metroCheckBox1.AutoSize = true;
@@ -2095,6 +2569,18 @@
             this.metroCheckBox1.TabIndex = 9;
             this.metroCheckBox1.Text = "DebugFrameIndex";
             this.metroCheckBox1.UseVisualStyleBackColor = true;
+            // 
+            // debugCaptureOutputCheckBox
+            // 
+            this.debugCaptureOutputCheckBox.AutoSize = true;
+            this.debugCaptureOutputCheckBox.Checked = global::ALVR.Properties.Settings.Default.debugCaptureOutput;
+            this.debugCaptureOutputCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "debugCaptureOutput", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.debugCaptureOutputCheckBox.Location = new System.Drawing.Point(3, 24);
+            this.debugCaptureOutputCheckBox.Name = "debugCaptureOutputCheckBox";
+            this.debugCaptureOutputCheckBox.Size = new System.Drawing.Size(138, 15);
+            this.debugCaptureOutputCheckBox.TabIndex = 9;
+            this.debugCaptureOutputCheckBox.Text = "DebugCaptureOutput";
+            this.debugCaptureOutputCheckBox.UseVisualStyleBackColor = true;
             // 
             // metroCheckBox2
             // 
@@ -2344,482 +2830,67 @@
             this.notifyIcon1.Text = "ALVR";
             this.notifyIcon1.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.notifyIcon1_MouseDoubleClick);
             // 
-            // flowLayoutPanel39
-            // 
-            this.flowLayoutPanel39.AutoSize = true;
-            this.flowLayoutPanel39.Controls.Add(this.flowLayoutPanel40);
-            this.flowLayoutPanel39.Controls.Add(this.flowLayoutPanel41);
-            this.flowLayoutPanel39.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel39.Location = new System.Drawing.Point(230, 372);
-            this.flowLayoutPanel39.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel39.Name = "flowLayoutPanel39";
-            this.flowLayoutPanel39.Size = new System.Drawing.Size(275, 29);
-            this.flowLayoutPanel39.TabIndex = 60;
-            this.flowLayoutPanel39.WrapContents = false;
-            // 
-            // flowLayoutPanel40
-            // 
-            this.flowLayoutPanel40.Controls.Add(this.metroLabel37);
-            this.flowLayoutPanel40.Controls.Add(this.sharpeningBox);
-            this.flowLayoutPanel40.Location = new System.Drawing.Point(0, 0);
-            this.flowLayoutPanel40.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel40.Name = "flowLayoutPanel40";
-            this.flowLayoutPanel40.Size = new System.Drawing.Size(128, 29);
-            this.flowLayoutPanel40.TabIndex = 54;
-            this.flowLayoutPanel40.WrapContents = false;
-            // 
-            // metroLabel37
-            // 
-            this.metroLabel37.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel37.AutoSize = true;
-            this.metroLabel37.Location = new System.Drawing.Point(2, 3);
-            this.metroLabel37.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.metroLabel37.Name = "metroLabel37";
-            this.metroLabel37.Size = new System.Drawing.Size(75, 19);
-            this.metroLabel37.TabIndex = 45;
-            this.metroLabel37.Text = "Sharpening";
-            // 
-            // flowLayoutPanel41
-            // 
-            this.flowLayoutPanel41.Location = new System.Drawing.Point(128, 0);
-            this.flowLayoutPanel41.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel41.Name = "flowLayoutPanel41";
-            this.flowLayoutPanel41.Size = new System.Drawing.Size(146, 29);
-            this.flowLayoutPanel41.TabIndex = 56;
-            // 
-            // soundCheckBox
-            // 
-            this.soundCheckBox.AutoSize = true;
-            this.soundCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableSound;
-            this.soundCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.soundCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableSound", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.soundCheckBox.Location = new System.Drawing.Point(3, 3);
-            this.soundCheckBox.Name = "soundCheckBox";
-            this.soundCheckBox.Size = new System.Drawing.Size(92, 15);
-            this.soundCheckBox.TabIndex = 2;
-            this.soundCheckBox.Text = "Steam sound";
-            this.soundCheckBox.UseVisualStyleBackColor = true;
-            this.soundCheckBox.CheckedChanged += new System.EventHandler(this.soundCheckBox_CheckedChanged);
-            // 
-            // streamMic
-            // 
-            this.streamMic.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.streamMic.AutoSize = true;
-            this.streamMic.Checked = global::ALVR.Properties.Settings.Default.streamMic;
-            this.streamMic.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "streamMic", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.streamMic.Location = new System.Drawing.Point(3, 73);
-            this.streamMic.Name = "streamMic";
-            this.streamMic.Size = new System.Drawing.Size(162, 15);
-            this.streamMic.TabIndex = 5;
-            this.streamMic.Text = "Stream Quest Microphone";
-            this.streamMic.UseVisualStyleBackColor = true;
-            this.streamMic.CheckedChanged += new System.EventHandler(this.metroCheckBox4_CheckedChanged);
-            // 
-            // defaultSoundDeviceCheckBox
-            // 
-            this.defaultSoundDeviceCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.defaultSoundDeviceCheckBox.AutoSize = true;
-            this.defaultSoundDeviceCheckBox.Checked = global::ALVR.Properties.Settings.Default.useDefaultSoundDevice;
-            this.defaultSoundDeviceCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.defaultSoundDeviceCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "useDefaultSoundDevice", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.defaultSoundDeviceCheckBox.Location = new System.Drawing.Point(20, 41);
-            this.defaultSoundDeviceCheckBox.Margin = new System.Windows.Forms.Padding(20, 3, 3, 3);
-            this.defaultSoundDeviceCheckBox.Name = "defaultSoundDeviceCheckBox";
-            this.defaultSoundDeviceCheckBox.Size = new System.Drawing.Size(119, 15);
-            this.defaultSoundDeviceCheckBox.TabIndex = 2;
-            this.defaultSoundDeviceCheckBox.Text = "Use default device";
-            this.defaultSoundDeviceCheckBox.UseVisualStyleBackColor = true;
-            this.defaultSoundDeviceCheckBox.CheckedChanged += new System.EventHandler(this.defaultSoundDeviceCheckBox_CheckedChanged);
-            // 
-            // sharpeningBox
-            // 
-            this.sharpeningBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "sharpening", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.sharpeningBox.DecimalPlaces = 2;
-            this.sharpeningBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.sharpeningBox.Location = new System.Drawing.Point(82, 3);
-            this.sharpeningBox.Maximum = new decimal(new int[] {
-            500,
-            0,
-            0,
-            131072});
-            this.sharpeningBox.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.sharpeningBox.Name = "sharpeningBox";
-            this.sharpeningBox.Size = new System.Drawing.Size(44, 20);
-            this.sharpeningBox.TabIndex = 44;
-            this.sharpeningBox.Value = global::ALVR.Properties.Settings.Default.sharpening;
-            // 
-            // forceNV12
-            // 
-            this.forceNV12.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.forceNV12.AutoSize = true;
-            this.forceNV12.Checked = global::ALVR.Properties.Settings.Default.nv12;
-            this.forceNV12.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "nv12", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.forceNV12.Location = new System.Drawing.Point(3, 3);
-            this.forceNV12.Margin = new System.Windows.Forms.Padding(3, 3, 0, 3);
-            this.forceNV12.Name = "forceNV12";
-            this.forceNV12.Size = new System.Drawing.Size(115, 15);
-            this.forceNV12.TabIndex = 35;
-            this.forceNV12.Text = "use custom NV12";
-            this.forceNV12.UseVisualStyleBackColor = true;
-            // 
-            // bitrateTrackBar
-            // 
-            this.bitrateTrackBar.BackColor = System.Drawing.Color.Transparent;
-            this.bitrateTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "bitrate", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.bitrateTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.bitrateTrackBar.Location = new System.Drawing.Point(233, 73);
-            this.bitrateTrackBar.Maximum = 250;
-            this.bitrateTrackBar.Minimum = 1;
-            this.bitrateTrackBar.Name = "bitrateTrackBar";
-            this.bitrateTrackBar.Size = new System.Drawing.Size(269, 25);
-            this.bitrateTrackBar.TabIndex = 2;
-            this.bitrateTrackBar.Text = "metroTrackBar1";
-            this.bitrateTrackBar.Value = global::ALVR.Properties.Settings.Default.bitrate;
-            this.bitrateTrackBar.ValueChanged += new System.EventHandler(this.bitrateTrackBar_ValueChanged);
-            this.bitrateTrackBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.bitrateTrackBar_Scroll);
-            // 
-            // enableColorCorrectionCheckBox
-            // 
-            this.enableColorCorrectionCheckBox.AutoSize = true;
-            this.enableColorCorrectionCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableColorCorrection;
-            this.enableColorCorrectionCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableColorCorrection", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.enableColorCorrectionCheckBox.Location = new System.Drawing.Point(233, 295);
-            this.enableColorCorrectionCheckBox.Name = "enableColorCorrectionCheckBox";
-            this.enableColorCorrectionCheckBox.Size = new System.Drawing.Size(58, 15);
-            this.enableColorCorrectionCheckBox.TabIndex = 40;
-            this.enableColorCorrectionCheckBox.Text = "Enable";
-            this.enableColorCorrectionCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // bufferTrackBar
-            // 
-            this.bufferTrackBar.BackColor = System.Drawing.Color.Transparent;
-            this.bufferTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "bufferOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.bufferTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.bufferTrackBar.Location = new System.Drawing.Point(233, 160);
-            this.bufferTrackBar.Minimum = -100;
-            this.bufferTrackBar.Name = "bufferTrackBar";
-            this.bufferTrackBar.Size = new System.Drawing.Size(269, 20);
-            this.bufferTrackBar.TabIndex = 2;
-            this.bufferTrackBar.Text = "metroTrackBar1";
-            this.bufferTrackBar.Value = global::ALVR.Properties.Settings.Default.bufferOffset;
-            this.bufferTrackBar.ValueChanged += new System.EventHandler(this.bufferTrackBar_ValueChanged);
-            this.bufferTrackBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.bufferTrackBar_Scroll);
-            // 
-            // foveationStrengthTrackBar
-            // 
-            this.foveationStrengthTrackBar.BackColor = System.Drawing.Color.Transparent;
-            this.foveationStrengthTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "foveationStrength", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.foveationStrengthTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.foveationStrengthTrackBar.LargeChange = 100;
-            this.foveationStrengthTrackBar.Location = new System.Drawing.Point(233, 240);
-            this.foveationStrengthTrackBar.Maximum = 500;
-            this.foveationStrengthTrackBar.MaximumSize = new System.Drawing.Size(0, 14);
-            this.foveationStrengthTrackBar.Name = "foveationStrengthTrackBar";
-            this.foveationStrengthTrackBar.Size = new System.Drawing.Size(269, 10);
-            this.foveationStrengthTrackBar.SmallChange = 10;
-            this.foveationStrengthTrackBar.TabIndex = 30;
-            this.foveationStrengthTrackBar.Text = "metroTrackBar1";
-            this.foveationStrengthTrackBar.Value = global::ALVR.Properties.Settings.Default.foveationStrength;
-            this.foveationStrengthTrackBar.ValueChanged += new System.EventHandler(this.FoveationStrengthTrackBar_ValueChanged);
-            // 
-            // foveationVerticalOffsetTrackBar
-            // 
-            this.foveationVerticalOffsetTrackBar.BackColor = System.Drawing.Color.Transparent;
-            this.foveationVerticalOffsetTrackBar.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "foveationVerticalOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.foveationVerticalOffsetTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.foveationVerticalOffsetTrackBar.LargeChange = 2;
-            this.foveationVerticalOffsetTrackBar.Location = new System.Drawing.Point(233, 275);
-            this.foveationVerticalOffsetTrackBar.Maximum = 10;
-            this.foveationVerticalOffsetTrackBar.Minimum = -10;
-            this.foveationVerticalOffsetTrackBar.MouseWheelBarPartitions = 1;
-            this.foveationVerticalOffsetTrackBar.Name = "foveationVerticalOffsetTrackBar";
-            this.foveationVerticalOffsetTrackBar.Size = new System.Drawing.Size(269, 14);
-            this.foveationVerticalOffsetTrackBar.TabIndex = 34;
-            this.foveationVerticalOffsetTrackBar.Text = "metroTrackBar1";
-            this.foveationVerticalOffsetTrackBar.Value = global::ALVR.Properties.Settings.Default.foveationVerticalOffset;
-            this.foveationVerticalOffsetTrackBar.ValueChanged += new System.EventHandler(this.FoveationVerticalOffsetTrackBar_ValueChanged);
-            // 
-            // saturationBox
-            // 
-            this.saturationBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "saturation", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.saturationBox.DecimalPlaces = 2;
-            this.saturationBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.saturationBox.Location = new System.Drawing.Point(75, 3);
-            this.saturationBox.Maximum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.saturationBox.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            -2147483648});
-            this.saturationBox.Name = "saturationBox";
-            this.saturationBox.Size = new System.Drawing.Size(46, 20);
-            this.saturationBox.TabIndex = 48;
-            this.saturationBox.Value = global::ALVR.Properties.Settings.Default.saturation;
-            // 
-            // contrastBox
-            // 
-            this.contrastBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "contrast", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.contrastBox.DecimalPlaces = 2;
-            this.contrastBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.contrastBox.Location = new System.Drawing.Point(65, 3);
-            this.contrastBox.Maximum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            131072});
-            this.contrastBox.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.contrastBox.Name = "contrastBox";
-            this.contrastBox.Size = new System.Drawing.Size(45, 20);
-            this.contrastBox.TabIndex = 46;
-            this.contrastBox.Value = global::ALVR.Properties.Settings.Default.contrast;
-            // 
-            // brightnessBox
-            // 
-            this.brightnessBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "brightness", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.brightnessBox.DecimalPlaces = 2;
-            this.brightnessBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.brightnessBox.Location = new System.Drawing.Point(75, 3);
-            this.brightnessBox.Maximum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            131072});
-            this.brightnessBox.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.brightnessBox.Name = "brightnessBox";
-            this.brightnessBox.Size = new System.Drawing.Size(44, 20);
-            this.brightnessBox.TabIndex = 44;
-            this.brightnessBox.Value = global::ALVR.Properties.Settings.Default.brightness;
-            // 
-            // gammaBox
-            // 
-            this.gammaBox.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "gamma", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.gammaBox.DecimalPlaces = 2;
-            this.gammaBox.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.gammaBox.Location = new System.Drawing.Point(63, 3);
-            this.gammaBox.Maximum = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
-            this.gammaBox.Name = "gammaBox";
-            this.gammaBox.Size = new System.Drawing.Size(45, 20);
-            this.gammaBox.TabIndex = 42;
-            this.gammaBox.Value = global::ALVR.Properties.Settings.Default.gamma;
-            // 
-            // controllerPoseOffset
-            // 
-            this.controllerPoseOffset.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.controllerPoseOffset.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "controllerPoseOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.controllerPoseOffset.Location = new System.Drawing.Point(147, 6);
-            this.controllerPoseOffset.Name = "controllerPoseOffset";
-            this.controllerPoseOffset.Size = new System.Drawing.Size(52, 19);
-            this.controllerPoseOffset.TabIndex = 21;
-            this.controllerPoseOffset.Text = global::ALVR.Properties.Settings.Default.controllerPoseOffset;
-            this.controllerPoseOffset.Click += new System.EventHandler(this.controllerPoseOffset_Click);
-            // 
-            // onlySteamVRCheckBox
-            // 
-            this.onlySteamVRCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.onlySteamVRCheckBox.AutoSize = true;
-            this.onlySteamVRCheckBox.Checked = global::ALVR.Properties.Settings.Default.onlySteamVR;
-            this.onlySteamVRCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "onlySteamVR", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.onlySteamVRCheckBox.Location = new System.Drawing.Point(53, 3);
-            this.onlySteamVRCheckBox.Name = "onlySteamVRCheckBox";
-            this.onlySteamVRCheckBox.Size = new System.Drawing.Size(221, 15);
-            this.onlySteamVRCheckBox.TabIndex = 29;
-            this.onlySteamVRCheckBox.Text = "Launch only SteamVR without Steam.";
-            this.onlySteamVRCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // steamAutoLaunch
-            // 
-            this.steamAutoLaunch.AutoSize = true;
-            this.steamAutoLaunch.Checked = global::ALVR.Properties.Settings.Default.steamAutolaunch;
-            this.steamAutoLaunch.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "steamAutolaunch", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.steamAutoLaunch.Location = new System.Drawing.Point(3, 3);
-            this.steamAutoLaunch.Name = "steamAutoLaunch";
-            this.steamAutoLaunch.Size = new System.Drawing.Size(206, 15);
-            this.steamAutoLaunch.TabIndex = 36;
-            this.steamAutoLaunch.Text = "Launch SteamVR on HMD connect";
-            this.steamAutoLaunch.UseVisualStyleBackColor = true;
-            // 
-            // launchMinimized
-            // 
-            this.launchMinimized.AutoSize = true;
-            this.launchMinimized.Checked = global::ALVR.Properties.Settings.Default.launchMinimized;
-            this.launchMinimized.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "launchMinimized", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.launchMinimized.Location = new System.Drawing.Point(3, 3);
-            this.launchMinimized.Name = "launchMinimized";
-            this.launchMinimized.Size = new System.Drawing.Size(151, 15);
-            this.launchMinimized.TabIndex = 0;
-            this.launchMinimized.Text = "Launch ALVR minimized";
-            this.launchMinimized.UseVisualStyleBackColor = true;
-            // 
-            // force60HzCheckBox
-            // 
-            this.force60HzCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.force60HzCheckBox.AutoSize = true;
-            this.force60HzCheckBox.Checked = global::ALVR.Properties.Settings.Default.force60Hz;
-            this.force60HzCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force60Hz", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.force60HzCheckBox.Location = new System.Drawing.Point(53, 85);
-            this.force60HzCheckBox.Name = "force60HzCheckBox";
-            this.force60HzCheckBox.Size = new System.Drawing.Size(81, 15);
-            this.force60HzCheckBox.TabIndex = 31;
-            this.force60HzCheckBox.Text = "Force 60Hz";
-            this.force60HzCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // suppressFrameDropCheckBox
-            // 
-            this.suppressFrameDropCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.suppressFrameDropCheckBox.AutoSize = true;
-            this.suppressFrameDropCheckBox.Checked = global::ALVR.Properties.Settings.Default.suppressFrameDrop;
-            this.suppressFrameDropCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "suppressFrameDrop", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.suppressFrameDropCheckBox.Location = new System.Drawing.Point(53, 106);
-            this.suppressFrameDropCheckBox.Name = "suppressFrameDropCheckBox";
-            this.suppressFrameDropCheckBox.Size = new System.Drawing.Size(132, 15);
-            this.suppressFrameDropCheckBox.TabIndex = 30;
-            this.suppressFrameDropCheckBox.Text = "Suppress frame drop";
-            this.suppressFrameDropCheckBox.UseVisualStyleBackColor = true;
-            this.suppressFrameDropCheckBox.CheckedChanged += new System.EventHandler(this.suppressFrameDropCheckBox_CheckedChanged);
-            // 
-            // disableThrottlingCheckBox
-            // 
-            this.disableThrottlingCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.disableThrottlingCheckBox.AutoSize = true;
-            this.disableThrottlingCheckBox.Checked = global::ALVR.Properties.Settings.Default.disableThrottling;
-            this.disableThrottlingCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableThrottling", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.disableThrottlingCheckBox.Location = new System.Drawing.Point(53, 127);
-            this.disableThrottlingCheckBox.Name = "disableThrottlingCheckBox";
-            this.disableThrottlingCheckBox.Size = new System.Drawing.Size(142, 15);
-            this.disableThrottlingCheckBox.TabIndex = 32;
-            this.disableThrottlingCheckBox.Text = "Disable send throttling";
-            this.disableThrottlingCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // disableController
-            // 
-            this.disableController.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.disableController.AutoSize = true;
-            this.disableController.Checked = global::ALVR.Properties.Settings.Default.disableController;
-            this.disableController.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableController", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.disableController.Location = new System.Drawing.Point(53, 148);
-            this.disableController.Name = "disableController";
-            this.disableController.Size = new System.Drawing.Size(115, 15);
-            this.disableController.TabIndex = 33;
-            this.disableController.Text = "Disable controller";
-            this.disableController.UseVisualStyleBackColor = true;
-            // 
-            // force3DOFCheckBox
-            // 
-            this.force3DOFCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.force3DOFCheckBox.AutoSize = true;
-            this.force3DOFCheckBox.Checked = global::ALVR.Properties.Settings.Default.force3DOF;
-            this.force3DOFCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force3DOF", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.force3DOFCheckBox.Location = new System.Drawing.Point(53, 169);
-            this.force3DOFCheckBox.Name = "force3DOFCheckBox";
-            this.force3DOFCheckBox.Size = new System.Drawing.Size(84, 15);
-            this.force3DOFCheckBox.TabIndex = 34;
-            this.force3DOFCheckBox.Text = "Force 3DOF";
-            this.force3DOFCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // aggressiveKeyframeResend
-            // 
-            this.aggressiveKeyframeResend.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.aggressiveKeyframeResend.AutoSize = true;
-            this.aggressiveKeyframeResend.Checked = global::ALVR.Properties.Settings.Default.aggressiveKeyframeResend;
-            this.aggressiveKeyframeResend.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "aggressiveKeyframeResend", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.aggressiveKeyframeResend.Location = new System.Drawing.Point(3, 3);
-            this.aggressiveKeyframeResend.Name = "aggressiveKeyframeResend";
-            this.aggressiveKeyframeResend.Size = new System.Drawing.Size(170, 15);
-            this.aggressiveKeyframeResend.TabIndex = 35;
-            this.aggressiveKeyframeResend.Text = "Aggressive keyframe resend";
-            this.aggressiveKeyframeResend.UseVisualStyleBackColor = true;
-            // 
-            // trackingFrameOffsetTextBox
-            // 
-            this.trackingFrameOffsetTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.trackingFrameOffsetTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "trackingFrameOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.trackingFrameOffsetTextBox.Location = new System.Drawing.Point(138, 3);
-            this.trackingFrameOffsetTextBox.Name = "trackingFrameOffsetTextBox";
-            this.trackingFrameOffsetTextBox.Size = new System.Drawing.Size(102, 25);
-            this.trackingFrameOffsetTextBox.TabIndex = 27;
-            this.trackingFrameOffsetTextBox.Text = global::ALVR.Properties.Settings.Default.trackingFrameOffset;
-            // 
-            // connectCommandTextBox
-            // 
-            this.connectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "connectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.connectCommandTextBox.Location = new System.Drawing.Point(85, 3);
-            this.connectCommandTextBox.Name = "connectCommandTextBox";
-            this.connectCommandTextBox.Size = new System.Drawing.Size(351, 25);
-            this.connectCommandTextBox.TabIndex = 23;
-            this.connectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.connectCommand;
-            // 
-            // disconnectCommandTextBox
-            // 
-            this.disconnectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "disconnectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.disconnectCommandTextBox.Location = new System.Drawing.Point(101, 3);
-            this.disconnectCommandTextBox.Name = "disconnectCommandTextBox";
-            this.disconnectCommandTextBox.Size = new System.Drawing.Size(383, 25);
-            this.disconnectCommandTextBox.TabIndex = 25;
-            this.disconnectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.disconnectCommand;
-            // 
-            // debugLogCheckBox
-            // 
-            this.debugLogCheckBox.AutoSize = true;
-            this.debugLogCheckBox.Checked = global::ALVR.Properties.Settings.Default.debugLog;
-            this.debugLogCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "debugLog", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.debugLogCheckBox.Location = new System.Drawing.Point(3, 3);
-            this.debugLogCheckBox.Name = "debugLogCheckBox";
-            this.debugLogCheckBox.Size = new System.Drawing.Size(78, 15);
-            this.debugLogCheckBox.TabIndex = 9;
-            this.debugLogCheckBox.Text = "DebugLog";
-            this.debugLogCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // debugCaptureOutputCheckBox
-            // 
-            this.debugCaptureOutputCheckBox.AutoSize = true;
-            this.debugCaptureOutputCheckBox.Checked = global::ALVR.Properties.Settings.Default.debugCaptureOutput;
-            this.debugCaptureOutputCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "debugCaptureOutput", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.debugCaptureOutputCheckBox.Location = new System.Drawing.Point(3, 24);
-            this.debugCaptureOutputCheckBox.Name = "debugCaptureOutputCheckBox";
-            this.debugCaptureOutputCheckBox.Size = new System.Drawing.Size(138, 15);
-            this.debugCaptureOutputCheckBox.TabIndex = 9;
-            this.debugCaptureOutputCheckBox.Text = "DebugCaptureOutput";
-            this.debugCaptureOutputCheckBox.UseVisualStyleBackColor = true;
+            // presetsTab
+            // 
+            this.presetsTab.Controls.Add(this.tableLayoutPanel2);
+            this.presetsTab.HorizontalScrollbarBarColor = true;
+            this.presetsTab.HorizontalScrollbarSize = 0;
+            this.presetsTab.Location = new System.Drawing.Point(4, 35);
+            this.presetsTab.Name = "presetsTab";
+            this.presetsTab.Size = new System.Drawing.Size(655, 417);
+            this.presetsTab.TabIndex = 9;
+            this.presetsTab.Text = "Presets";
+            this.presetsTab.VerticalScrollbarBarColor = true;
+            this.presetsTab.VerticalScrollbarSize = 0;
+            // 
+            // tableLayoutPanel2
+            // 
+            this.tableLayoutPanel2.BackColor = System.Drawing.SystemColors.Window;
+            this.tableLayoutPanel2.ColumnCount = 2;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel2.Controls.Add(this.metroLabel38, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel42, 1, 0);
+            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            this.tableLayoutPanel2.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
+            this.tableLayoutPanel2.RowCount = 2;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(655, 417);
+            this.tableLayoutPanel2.TabIndex = 9;
+            // 
+            // revertToDefaultButton
+            // 
+            this.revertToDefaultButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.revertToDefaultButton.Location = new System.Drawing.Point(3, 3);
+            this.revertToDefaultButton.Name = "revertToDefaultButton";
+            this.revertToDefaultButton.Size = new System.Drawing.Size(163, 25);
+            this.revertToDefaultButton.TabIndex = 23;
+            this.revertToDefaultButton.Text = "Revert all settings to default";
+            this.revertToDefaultButton.Click += new System.EventHandler(this.revertToDefaultButton_Click);
+            // 
+            // flowLayoutPanel42
+            // 
+            this.flowLayoutPanel42.AutoSize = true;
+            this.flowLayoutPanel42.Controls.Add(this.revertToDefaultButton);
+            this.flowLayoutPanel42.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel42.Location = new System.Drawing.Point(103, 13);
+            this.flowLayoutPanel42.Name = "flowLayoutPanel42";
+            this.flowLayoutPanel42.Size = new System.Drawing.Size(549, 31);
+            this.flowLayoutPanel42.TabIndex = 26;
+            // 
+            // metroLabel38
+            // 
+            this.metroLabel38.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.metroLabel38.AutoSize = true;
+            this.metroLabel38.Location = new System.Drawing.Point(46, 19);
+            this.metroLabel38.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.metroLabel38.Name = "metroLabel38";
+            this.metroLabel38.Size = new System.Drawing.Size(54, 19);
+            this.metroLabel38.TabIndex = 27;
+            this.metroLabel38.Text = "General";
             // 
             // Launcher
             // 
@@ -2857,6 +2928,10 @@
             this.videoTab.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
+            this.flowLayoutPanel39.ResumeLayout(false);
+            this.flowLayoutPanel40.ResumeLayout(false);
+            this.flowLayoutPanel40.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.sharpeningBox)).EndInit();
             this.flowLayoutPanel2.ResumeLayout(false);
             this.flowLayoutPanel2.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
@@ -2884,13 +2959,17 @@
             this.flowLayoutPanel32.ResumeLayout(false);
             this.flowLayoutPanel28.ResumeLayout(false);
             this.flowLayoutPanel28.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.saturationBox)).EndInit();
             this.flowLayoutPanel30.ResumeLayout(false);
             this.flowLayoutPanel30.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.contrastBox)).EndInit();
             this.flowLayoutPanel33.ResumeLayout(false);
             this.flowLayoutPanel29.ResumeLayout(false);
             this.flowLayoutPanel29.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.brightnessBox)).EndInit();
             this.flowLayoutPanel31.ResumeLayout(false);
             this.flowLayoutPanel31.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.gammaBox)).EndInit();
             this.flowLayoutPanel34.ResumeLayout(false);
             this.flowLayoutPanel34.PerformLayout();
             this.soundTab.ResumeLayout(false);
@@ -2940,14 +3019,10 @@
             this.flowLayoutPanel23.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.resolutionBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            this.flowLayoutPanel39.ResumeLayout(false);
-            this.flowLayoutPanel40.ResumeLayout(false);
-            this.flowLayoutPanel40.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.sharpeningBox)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.saturationBox)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.contrastBox)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.brightnessBox)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.gammaBox)).EndInit();
+            this.presetsTab.ResumeLayout(false);
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            this.flowLayoutPanel42.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -3151,6 +3226,11 @@
         private MetroFramework.Controls.MetroLabel metroLabel37;
         private System.Windows.Forms.NumericUpDown sharpeningBox;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel41;
+        private MetroFramework.Controls.MetroTabPage presetsTab;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private MetroFramework.Controls.MetroButton revertToDefaultButton;
+        private MetroFramework.Controls.MetroLabel metroLabel38;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel42;
     }
 }
 

--- a/ALVR/Launcher.Designer.cs
+++ b/ALVR/Launcher.Designer.cs
@@ -68,67 +68,6 @@
             this.closeServerButton = new MetroFramework.Controls.MetroButton();
             this.connectedLabel = new MetroFramework.Controls.MetroLabel();
             this.autoConnectCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.presetsTab = new MetroFramework.Controls.MetroTabPage();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.flowLayoutPanel44 = new System.Windows.Forms.FlowLayoutPanel();
-            this.fixBoneworksControllersButton = new MetroFramework.Controls.MetroButton();
-            this.metroLabel38 = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel42 = new System.Windows.Forms.FlowLayoutPanel();
-            this.revertToDefaultButton = new MetroFramework.Controls.MetroButton();
-            this.metroLabel42 = new MetroFramework.Controls.MetroLabel();
-            this.otherTab = new MetroFramework.Controls.MetroTabPage();
-            this.tableLayoutPanel11 = new System.Windows.Forms.TableLayoutPanel();
-            this.flowLayoutPanel26 = new System.Windows.Forms.FlowLayoutPanel();
-            this.onlySteamVRCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.flowLayoutPanel35 = new System.Windows.Forms.FlowLayoutPanel();
-            this.steamAutoLaunch = new MetroFramework.Controls.MetroCheckBox();
-            this.autoLaunchHelp = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel36 = new System.Windows.Forms.FlowLayoutPanel();
-            this.launchMinimized = new MetroFramework.Controls.MetroCheckBox();
-            this.force60HzCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.suppressFrameDropCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.disableThrottlingCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.disableController = new MetroFramework.Controls.MetroCheckBox();
-            this.force3DOFCheckBox = new MetroFramework.Controls.MetroCheckBox();
-            this.flowLayoutPanel15 = new System.Windows.Forms.FlowLayoutPanel();
-            this.aggressiveKeyframeResend = new MetroFramework.Controls.MetroCheckBox();
-            this.aggressiveKeyframeResendHelp = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel17 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel29 = new MetroFramework.Controls.MetroLabel();
-            this.trackingFrameOffsetTextBox = new MetroFramework.Controls.MetroTextBox();
-            this.saveTrackingFrameOffsetButton = new MetroFramework.Controls.MetroButton();
-            this.metroLabel30 = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel24 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel27 = new MetroFramework.Controls.MetroLabel();
-            this.connectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
-            this.refConnectCommandButton = new MetroFramework.Controls.MetroButton();
-            this.metroLabel26 = new MetroFramework.Controls.MetroLabel();
-            this.flowLayoutPanel25 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel28 = new MetroFramework.Controls.MetroLabel();
-            this.disconnectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
-            this.refDisconnectCommandButton = new MetroFramework.Controls.MetroButton();
-            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-            this.flowLayoutPanel43 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel40 = new MetroFramework.Controls.MetroLabel();
-            this.controllerRotationOffsetHelp = new MetroFramework.Controls.MetroLabel();
-            this.numericUpDown4 = new System.Windows.Forms.NumericUpDown();
-            this.numericUpDown5 = new System.Windows.Forms.NumericUpDown();
-            this.numericUpDown6 = new System.Windows.Forms.NumericUpDown();
-            this.flowLayoutPanel37 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel39 = new MetroFramework.Controls.MetroLabel();
-            this.controllerPositionOffsetHelp = new MetroFramework.Controls.MetroLabel();
-            this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
-            this.numericUpDown2 = new System.Windows.Forms.NumericUpDown();
-            this.numericUpDown3 = new System.Windows.Forms.NumericUpDown();
-            this.flowLayoutPanel38 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel36 = new MetroFramework.Controls.MetroLabel();
-            this.handTrackingModeHelp = new MetroFramework.Controls.MetroLabel();
-            this.controllerModeComboBox = new MetroFramework.Controls.MetroComboBox();
-            this.flowLayoutPanel16 = new System.Windows.Forms.FlowLayoutPanel();
-            this.metroLabel12 = new MetroFramework.Controls.MetroLabel();
-            this.controllerPoseOffset = new MetroFramework.Controls.MetroTextBox();
-            this.metroButton1 = new MetroFramework.Controls.MetroButton();
-            this.metroLabel41 = new MetroFramework.Controls.MetroLabel();
             this.videoTab = new MetroFramework.Controls.MetroTabPage();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel39 = new System.Windows.Forms.FlowLayoutPanel();
@@ -215,6 +154,68 @@
             this.metroLabel20 = new MetroFramework.Controls.MetroLabel();
             this.metroLink1 = new MetroFramework.Controls.MetroLink();
             this.defaultSoundDeviceCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.otherTab = new MetroFramework.Controls.MetroTabPage();
+            this.tableLayoutPanel11 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel45 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel41 = new MetroFramework.Controls.MetroLabel();
+            this.flowLayoutPanel16 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel12 = new MetroFramework.Controls.MetroLabel();
+            this.controllerPoseOffset = new MetroFramework.Controls.MetroTextBox();
+            this.metroButton1 = new MetroFramework.Controls.MetroButton();
+            this.flowLayoutPanel38 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel36 = new MetroFramework.Controls.MetroLabel();
+            this.handTrackingModeHelp = new MetroFramework.Controls.MetroLabel();
+            this.controllerModeComboBox = new MetroFramework.Controls.MetroComboBox();
+            this.flowLayoutPanel37 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel39 = new MetroFramework.Controls.MetroLabel();
+            this.controllerPositionOffsetHelp = new MetroFramework.Controls.MetroLabel();
+            this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown2 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown3 = new System.Windows.Forms.NumericUpDown();
+            this.flowLayoutPanel43 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel40 = new MetroFramework.Controls.MetroLabel();
+            this.controllerRotationOffsetHelp = new MetroFramework.Controls.MetroLabel();
+            this.numericUpDown4 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown5 = new System.Windows.Forms.NumericUpDown();
+            this.numericUpDown6 = new System.Windows.Forms.NumericUpDown();
+            this.flowLayoutPanel26 = new System.Windows.Forms.FlowLayoutPanel();
+            this.onlySteamVRCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.flowLayoutPanel35 = new System.Windows.Forms.FlowLayoutPanel();
+            this.steamAutoLaunch = new MetroFramework.Controls.MetroCheckBox();
+            this.autoLaunchHelp = new MetroFramework.Controls.MetroLabel();
+            this.flowLayoutPanel36 = new System.Windows.Forms.FlowLayoutPanel();
+            this.launchMinimized = new MetroFramework.Controls.MetroCheckBox();
+            this.force60HzCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.suppressFrameDropCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.disableThrottlingCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.disableController = new MetroFramework.Controls.MetroCheckBox();
+            this.force3DOFCheckBox = new MetroFramework.Controls.MetroCheckBox();
+            this.flowLayoutPanel15 = new System.Windows.Forms.FlowLayoutPanel();
+            this.aggressiveKeyframeResend = new MetroFramework.Controls.MetroCheckBox();
+            this.aggressiveKeyframeResendHelp = new MetroFramework.Controls.MetroLabel();
+            this.flowLayoutPanel17 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel29 = new MetroFramework.Controls.MetroLabel();
+            this.trackingFrameOffsetTextBox = new MetroFramework.Controls.MetroTextBox();
+            this.saveTrackingFrameOffsetButton = new MetroFramework.Controls.MetroButton();
+            this.metroLabel30 = new MetroFramework.Controls.MetroLabel();
+            this.flowLayoutPanel24 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel27 = new MetroFramework.Controls.MetroLabel();
+            this.connectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
+            this.refConnectCommandButton = new MetroFramework.Controls.MetroButton();
+            this.metroLabel26 = new MetroFramework.Controls.MetroLabel();
+            this.flowLayoutPanel25 = new System.Windows.Forms.FlowLayoutPanel();
+            this.metroLabel28 = new MetroFramework.Controls.MetroLabel();
+            this.disconnectCommandTextBox = new MetroFramework.Controls.MetroTextBox();
+            this.refDisconnectCommandButton = new MetroFramework.Controls.MetroButton();
+            this.presetsTab = new MetroFramework.Controls.MetroTabPage();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel44 = new System.Windows.Forms.FlowLayoutPanel();
+            this.fixBoneworksControllersButton = new MetroFramework.Controls.MetroButton();
+            this.metroLabel38 = new MetroFramework.Controls.MetroLabel();
+            this.flowLayoutPanel42 = new System.Windows.Forms.FlowLayoutPanel();
+            this.revertToDefaultButton = new MetroFramework.Controls.MetroButton();
+            this.defaultControllerOffsetsButton = new MetroFramework.Controls.MetroButton();
+            this.metroLabel42 = new MetroFramework.Controls.MetroLabel();
             this.debugTab = new MetroFramework.Controls.MetroTabPage();
             this.tableLayoutPanel14 = new System.Windows.Forms.TableLayoutPanel();
             this.metroLabel5 = new MetroFramework.Controls.MetroLabel();
@@ -268,30 +269,6 @@
             this.connectedPanel.SuspendLayout();
             this.tableLayoutPanel8.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.statDataGridView)).BeginInit();
-            this.presetsTab.SuspendLayout();
-            this.tableLayoutPanel2.SuspendLayout();
-            this.flowLayoutPanel44.SuspendLayout();
-            this.flowLayoutPanel42.SuspendLayout();
-            this.otherTab.SuspendLayout();
-            this.tableLayoutPanel11.SuspendLayout();
-            this.flowLayoutPanel26.SuspendLayout();
-            this.flowLayoutPanel35.SuspendLayout();
-            this.flowLayoutPanel36.SuspendLayout();
-            this.flowLayoutPanel15.SuspendLayout();
-            this.flowLayoutPanel17.SuspendLayout();
-            this.flowLayoutPanel24.SuspendLayout();
-            this.flowLayoutPanel25.SuspendLayout();
-            this.tableLayoutPanel3.SuspendLayout();
-            this.flowLayoutPanel43.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown4)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown5)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown6)).BeginInit();
-            this.flowLayoutPanel37.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).BeginInit();
-            this.flowLayoutPanel38.SuspendLayout();
-            this.flowLayoutPanel16.SuspendLayout();
             this.videoTab.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel39.SuspendLayout();
@@ -324,6 +301,30 @@
             this.tableLayoutPanel9.SuspendLayout();
             this.flowLayoutPanel13.SuspendLayout();
             this.flowLayoutPanel14.SuspendLayout();
+            this.otherTab.SuspendLayout();
+            this.tableLayoutPanel11.SuspendLayout();
+            this.flowLayoutPanel45.SuspendLayout();
+            this.flowLayoutPanel16.SuspendLayout();
+            this.flowLayoutPanel38.SuspendLayout();
+            this.flowLayoutPanel37.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).BeginInit();
+            this.flowLayoutPanel43.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown4)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown5)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown6)).BeginInit();
+            this.flowLayoutPanel26.SuspendLayout();
+            this.flowLayoutPanel35.SuspendLayout();
+            this.flowLayoutPanel36.SuspendLayout();
+            this.flowLayoutPanel15.SuspendLayout();
+            this.flowLayoutPanel17.SuspendLayout();
+            this.flowLayoutPanel24.SuspendLayout();
+            this.flowLayoutPanel25.SuspendLayout();
+            this.presetsTab.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            this.flowLayoutPanel44.SuspendLayout();
+            this.flowLayoutPanel42.SuspendLayout();
             this.debugTab.SuspendLayout();
             this.tableLayoutPanel14.SuspendLayout();
             this.flowLayoutPanel18.SuspendLayout();
@@ -800,806 +801,6 @@
             this.autoConnectCheckBox.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.autoConnectCheckBox.UseVisualStyleBackColor = true;
             this.autoConnectCheckBox.CheckedChanged += new System.EventHandler(this.autoConnectCheckBox_CheckedChanged);
-            // 
-            // presetsTab
-            // 
-            this.presetsTab.Controls.Add(this.tableLayoutPanel2);
-            this.presetsTab.HorizontalScrollbarBarColor = true;
-            this.presetsTab.HorizontalScrollbarSize = 0;
-            this.presetsTab.Location = new System.Drawing.Point(4, 35);
-            this.presetsTab.Name = "presetsTab";
-            this.presetsTab.Size = new System.Drawing.Size(655, 417);
-            this.presetsTab.TabIndex = 9;
-            this.presetsTab.Text = "Presets";
-            this.presetsTab.VerticalScrollbarBarColor = true;
-            this.presetsTab.VerticalScrollbarSize = 0;
-            // 
-            // tableLayoutPanel2
-            // 
-            this.tableLayoutPanel2.BackColor = System.Drawing.SystemColors.Window;
-            this.tableLayoutPanel2.ColumnCount = 2;
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel44, 0, 1);
-            this.tableLayoutPanel2.Controls.Add(this.metroLabel38, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel42, 1, 0);
-            this.tableLayoutPanel2.Controls.Add(this.metroLabel42, 0, 1);
-            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
-            this.tableLayoutPanel2.RowCount = 3;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(655, 417);
-            this.tableLayoutPanel2.TabIndex = 9;
-            // 
-            // flowLayoutPanel44
-            // 
-            this.flowLayoutPanel44.AutoSize = true;
-            this.flowLayoutPanel44.Controls.Add(this.fixBoneworksControllersButton);
-            this.flowLayoutPanel44.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel44.Location = new System.Drawing.Point(103, 50);
-            this.flowLayoutPanel44.Name = "flowLayoutPanel44";
-            this.flowLayoutPanel44.Size = new System.Drawing.Size(549, 31);
-            this.flowLayoutPanel44.TabIndex = 29;
-            // 
-            // fixBoneworksControllersButton
-            // 
-            this.fixBoneworksControllersButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.fixBoneworksControllersButton.Location = new System.Drawing.Point(3, 3);
-            this.fixBoneworksControllersButton.Name = "fixBoneworksControllersButton";
-            this.fixBoneworksControllersButton.Size = new System.Drawing.Size(163, 25);
-            this.fixBoneworksControllersButton.TabIndex = 23;
-            this.fixBoneworksControllersButton.Text = "Boneworks controllers";
-            this.fixBoneworksControllersButton.Click += new System.EventHandler(this.fixBoneworksControllersButton_Click);
-            // 
-            // metroLabel38
-            // 
-            this.metroLabel38.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.metroLabel38.AutoSize = true;
-            this.metroLabel38.Location = new System.Drawing.Point(46, 19);
-            this.metroLabel38.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.metroLabel38.Name = "metroLabel38";
-            this.metroLabel38.Size = new System.Drawing.Size(54, 19);
-            this.metroLabel38.TabIndex = 27;
-            this.metroLabel38.Text = "General";
-            // 
-            // flowLayoutPanel42
-            // 
-            this.flowLayoutPanel42.AutoSize = true;
-            this.flowLayoutPanel42.Controls.Add(this.revertToDefaultButton);
-            this.flowLayoutPanel42.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel42.Location = new System.Drawing.Point(103, 13);
-            this.flowLayoutPanel42.Name = "flowLayoutPanel42";
-            this.flowLayoutPanel42.Size = new System.Drawing.Size(549, 31);
-            this.flowLayoutPanel42.TabIndex = 26;
-            // 
-            // revertToDefaultButton
-            // 
-            this.revertToDefaultButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.revertToDefaultButton.Location = new System.Drawing.Point(3, 3);
-            this.revertToDefaultButton.Name = "revertToDefaultButton";
-            this.revertToDefaultButton.Size = new System.Drawing.Size(163, 25);
-            this.revertToDefaultButton.TabIndex = 23;
-            this.revertToDefaultButton.Text = "Revert all settings to default";
-            this.revertToDefaultButton.Click += new System.EventHandler(this.revertToDefaultButton_Click);
-            // 
-            // metroLabel42
-            // 
-            this.metroLabel42.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.metroLabel42.AutoSize = true;
-            this.metroLabel42.Location = new System.Drawing.Point(63, 56);
-            this.metroLabel42.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.metroLabel42.Name = "metroLabel42";
-            this.metroLabel42.Size = new System.Drawing.Size(37, 19);
-            this.metroLabel42.TabIndex = 28;
-            this.metroLabel42.Text = "Fixes";
-            // 
-            // otherTab
-            // 
-            this.otherTab.Controls.Add(this.tableLayoutPanel11);
-            this.otherTab.HorizontalScrollbarBarColor = true;
-            this.otherTab.HorizontalScrollbarSize = 0;
-            this.otherTab.Location = new System.Drawing.Point(4, 35);
-            this.otherTab.Name = "otherTab";
-            this.otherTab.Size = new System.Drawing.Size(655, 417);
-            this.otherTab.TabIndex = 7;
-            this.otherTab.Text = "Other";
-            this.otherTab.VerticalScrollbar = true;
-            this.otherTab.VerticalScrollbarBarColor = true;
-            this.otherTab.VerticalScrollbarSize = 0;
-            // 
-            // tableLayoutPanel11
-            // 
-            this.tableLayoutPanel11.BackColor = System.Drawing.SystemColors.Window;
-            this.tableLayoutPanel11.ColumnCount = 2;
-            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel26, 1, 0);
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel17, 0, 6);
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel24, 0, 4);
-            this.tableLayoutPanel11.Controls.Add(this.metroLabel26, 0, 3);
-            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel25, 0, 5);
-            this.tableLayoutPanel11.Controls.Add(this.tableLayoutPanel3, 0, 0);
-            this.tableLayoutPanel11.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel11.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel11.Name = "tableLayoutPanel11";
-            this.tableLayoutPanel11.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
-            this.tableLayoutPanel11.RowCount = 7;
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel11.Size = new System.Drawing.Size(655, 417);
-            this.tableLayoutPanel11.TabIndex = 37;
-            this.tableLayoutPanel11.Paint += new System.Windows.Forms.PaintEventHandler(this.tableLayoutPanel11_Paint);
-            // 
-            // flowLayoutPanel26
-            // 
-            this.flowLayoutPanel26.AutoSize = true;
-            this.flowLayoutPanel26.Controls.Add(this.onlySteamVRCheckBox);
-            this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel35);
-            this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel36);
-            this.flowLayoutPanel26.Controls.Add(this.force60HzCheckBox);
-            this.flowLayoutPanel26.Controls.Add(this.suppressFrameDropCheckBox);
-            this.flowLayoutPanel26.Controls.Add(this.disableThrottlingCheckBox);
-            this.flowLayoutPanel26.Controls.Add(this.disableController);
-            this.flowLayoutPanel26.Controls.Add(this.force3DOFCheckBox);
-            this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel15);
-            this.flowLayoutPanel26.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel26.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanel26.Location = new System.Drawing.Point(414, 13);
-            this.flowLayoutPanel26.Name = "flowLayoutPanel26";
-            this.flowLayoutPanel26.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
-            this.flowLayoutPanel26.Size = new System.Drawing.Size(238, 276);
-            this.flowLayoutPanel26.TabIndex = 40;
-            this.flowLayoutPanel26.WrapContents = false;
-            // 
-            // onlySteamVRCheckBox
-            // 
-            this.onlySteamVRCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.onlySteamVRCheckBox.AutoSize = true;
-            this.onlySteamVRCheckBox.Checked = global::ALVR.Properties.Settings.Default.onlySteamVR;
-            this.onlySteamVRCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "onlySteamVR", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.onlySteamVRCheckBox.Location = new System.Drawing.Point(8, 3);
-            this.onlySteamVRCheckBox.Name = "onlySteamVRCheckBox";
-            this.onlySteamVRCheckBox.Size = new System.Drawing.Size(221, 15);
-            this.onlySteamVRCheckBox.TabIndex = 29;
-            this.onlySteamVRCheckBox.Text = "Launch only SteamVR without Steam.";
-            this.onlySteamVRCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // flowLayoutPanel35
-            // 
-            this.flowLayoutPanel35.Controls.Add(this.steamAutoLaunch);
-            this.flowLayoutPanel35.Controls.Add(this.autoLaunchHelp);
-            this.flowLayoutPanel35.Location = new System.Drawing.Point(5, 21);
-            this.flowLayoutPanel35.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel35.Name = "flowLayoutPanel35";
-            this.flowLayoutPanel35.Size = new System.Drawing.Size(233, 21);
-            this.flowLayoutPanel35.TabIndex = 37;
-            // 
-            // steamAutoLaunch
-            // 
-            this.steamAutoLaunch.AutoSize = true;
-            this.steamAutoLaunch.Checked = global::ALVR.Properties.Settings.Default.steamAutolaunch;
-            this.steamAutoLaunch.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "steamAutolaunch", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.steamAutoLaunch.Location = new System.Drawing.Point(3, 3);
-            this.steamAutoLaunch.Name = "steamAutoLaunch";
-            this.steamAutoLaunch.Size = new System.Drawing.Size(206, 15);
-            this.steamAutoLaunch.TabIndex = 36;
-            this.steamAutoLaunch.Text = "Launch SteamVR on HMD connect";
-            this.steamAutoLaunch.UseVisualStyleBackColor = true;
-            // 
-            // autoLaunchHelp
-            // 
-            this.autoLaunchHelp.AutoSize = true;
-            this.autoLaunchHelp.Location = new System.Drawing.Point(215, 0);
-            this.autoLaunchHelp.Name = "autoLaunchHelp";
-            this.autoLaunchHelp.Size = new System.Drawing.Size(15, 19);
-            this.autoLaunchHelp.TabIndex = 37;
-            this.autoLaunchHelp.Text = "?";
-            this.autoLaunchHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // flowLayoutPanel36
-            // 
-            this.flowLayoutPanel36.AutoSize = true;
-            this.flowLayoutPanel36.Controls.Add(this.launchMinimized);
-            this.flowLayoutPanel36.Location = new System.Drawing.Point(5, 42);
-            this.flowLayoutPanel36.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel36.Name = "flowLayoutPanel36";
-            this.flowLayoutPanel36.Size = new System.Drawing.Size(157, 21);
-            this.flowLayoutPanel36.TabIndex = 38;
-            // 
-            // launchMinimized
-            // 
-            this.launchMinimized.AutoSize = true;
-            this.launchMinimized.Checked = global::ALVR.Properties.Settings.Default.launchMinimized;
-            this.launchMinimized.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "launchMinimized", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.launchMinimized.Location = new System.Drawing.Point(3, 3);
-            this.launchMinimized.Name = "launchMinimized";
-            this.launchMinimized.Size = new System.Drawing.Size(151, 15);
-            this.launchMinimized.TabIndex = 0;
-            this.launchMinimized.Text = "Launch ALVR minimized";
-            this.launchMinimized.UseVisualStyleBackColor = true;
-            // 
-            // force60HzCheckBox
-            // 
-            this.force60HzCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.force60HzCheckBox.AutoSize = true;
-            this.force60HzCheckBox.Checked = global::ALVR.Properties.Settings.Default.force60Hz;
-            this.force60HzCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force60Hz", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.force60HzCheckBox.Location = new System.Drawing.Point(8, 66);
-            this.force60HzCheckBox.Name = "force60HzCheckBox";
-            this.force60HzCheckBox.Size = new System.Drawing.Size(81, 15);
-            this.force60HzCheckBox.TabIndex = 31;
-            this.force60HzCheckBox.Text = "Force 60Hz";
-            this.force60HzCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // suppressFrameDropCheckBox
-            // 
-            this.suppressFrameDropCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.suppressFrameDropCheckBox.AutoSize = true;
-            this.suppressFrameDropCheckBox.Checked = global::ALVR.Properties.Settings.Default.suppressFrameDrop;
-            this.suppressFrameDropCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "suppressFrameDrop", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.suppressFrameDropCheckBox.Location = new System.Drawing.Point(8, 87);
-            this.suppressFrameDropCheckBox.Name = "suppressFrameDropCheckBox";
-            this.suppressFrameDropCheckBox.Size = new System.Drawing.Size(132, 15);
-            this.suppressFrameDropCheckBox.TabIndex = 30;
-            this.suppressFrameDropCheckBox.Text = "Suppress frame drop";
-            this.suppressFrameDropCheckBox.UseVisualStyleBackColor = true;
-            this.suppressFrameDropCheckBox.CheckedChanged += new System.EventHandler(this.suppressFrameDropCheckBox_CheckedChanged);
-            // 
-            // disableThrottlingCheckBox
-            // 
-            this.disableThrottlingCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.disableThrottlingCheckBox.AutoSize = true;
-            this.disableThrottlingCheckBox.Checked = global::ALVR.Properties.Settings.Default.disableThrottling;
-            this.disableThrottlingCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableThrottling", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.disableThrottlingCheckBox.Location = new System.Drawing.Point(8, 108);
-            this.disableThrottlingCheckBox.Name = "disableThrottlingCheckBox";
-            this.disableThrottlingCheckBox.Size = new System.Drawing.Size(142, 15);
-            this.disableThrottlingCheckBox.TabIndex = 32;
-            this.disableThrottlingCheckBox.Text = "Disable send throttling";
-            this.disableThrottlingCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // disableController
-            // 
-            this.disableController.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.disableController.AutoSize = true;
-            this.disableController.Checked = global::ALVR.Properties.Settings.Default.disableController;
-            this.disableController.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableController", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.disableController.Location = new System.Drawing.Point(8, 129);
-            this.disableController.Name = "disableController";
-            this.disableController.Size = new System.Drawing.Size(115, 15);
-            this.disableController.TabIndex = 33;
-            this.disableController.Text = "Disable controller";
-            this.disableController.UseVisualStyleBackColor = true;
-            // 
-            // force3DOFCheckBox
-            // 
-            this.force3DOFCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.force3DOFCheckBox.AutoSize = true;
-            this.force3DOFCheckBox.Checked = global::ALVR.Properties.Settings.Default.force3DOF;
-            this.force3DOFCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force3DOF", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.force3DOFCheckBox.Location = new System.Drawing.Point(8, 150);
-            this.force3DOFCheckBox.Name = "force3DOFCheckBox";
-            this.force3DOFCheckBox.Size = new System.Drawing.Size(84, 15);
-            this.force3DOFCheckBox.TabIndex = 34;
-            this.force3DOFCheckBox.Text = "Force 3DOF";
-            this.force3DOFCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // flowLayoutPanel15
-            // 
-            this.flowLayoutPanel15.AutoSize = true;
-            this.flowLayoutPanel15.Controls.Add(this.aggressiveKeyframeResend);
-            this.flowLayoutPanel15.Controls.Add(this.aggressiveKeyframeResendHelp);
-            this.flowLayoutPanel15.Location = new System.Drawing.Point(5, 168);
-            this.flowLayoutPanel15.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel15.Name = "flowLayoutPanel15";
-            this.flowLayoutPanel15.Size = new System.Drawing.Size(194, 21);
-            this.flowLayoutPanel15.TabIndex = 35;
-            // 
-            // aggressiveKeyframeResend
-            // 
-            this.aggressiveKeyframeResend.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.aggressiveKeyframeResend.AutoSize = true;
-            this.aggressiveKeyframeResend.Checked = global::ALVR.Properties.Settings.Default.aggressiveKeyframeResend;
-            this.aggressiveKeyframeResend.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "aggressiveKeyframeResend", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.aggressiveKeyframeResend.Location = new System.Drawing.Point(3, 3);
-            this.aggressiveKeyframeResend.Name = "aggressiveKeyframeResend";
-            this.aggressiveKeyframeResend.Size = new System.Drawing.Size(170, 15);
-            this.aggressiveKeyframeResend.TabIndex = 35;
-            this.aggressiveKeyframeResend.Text = "Aggressive keyframe resend";
-            this.aggressiveKeyframeResend.UseVisualStyleBackColor = true;
-            // 
-            // aggressiveKeyframeResendHelp
-            // 
-            this.aggressiveKeyframeResendHelp.AutoSize = true;
-            this.aggressiveKeyframeResendHelp.BackColor = System.Drawing.SystemColors.ControlDark;
-            this.aggressiveKeyframeResendHelp.FontSize = MetroFramework.MetroLabelSize.Small;
-            this.aggressiveKeyframeResendHelp.Location = new System.Drawing.Point(179, 0);
-            this.aggressiveKeyframeResendHelp.Name = "aggressiveKeyframeResendHelp";
-            this.aggressiveKeyframeResendHelp.Size = new System.Drawing.Size(12, 15);
-            this.aggressiveKeyframeResendHelp.Style = MetroFramework.MetroColorStyle.Blue;
-            this.aggressiveKeyframeResendHelp.TabIndex = 0;
-            this.aggressiveKeyframeResendHelp.Text = "?";
-            this.aggressiveKeyframeResendHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // flowLayoutPanel17
-            // 
-            this.flowLayoutPanel17.AutoSize = true;
-            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel17, 2);
-            this.flowLayoutPanel17.Controls.Add(this.metroLabel29);
-            this.flowLayoutPanel17.Controls.Add(this.trackingFrameOffsetTextBox);
-            this.flowLayoutPanel17.Controls.Add(this.saveTrackingFrameOffsetButton);
-            this.flowLayoutPanel17.Controls.Add(this.metroLabel30);
-            this.flowLayoutPanel17.Location = new System.Drawing.Point(3, 376);
-            this.flowLayoutPanel17.Name = "flowLayoutPanel17";
-            this.flowLayoutPanel17.Size = new System.Drawing.Size(609, 38);
-            this.flowLayoutPanel17.TabIndex = 0;
-            this.flowLayoutPanel17.WrapContents = false;
-            // 
-            // metroLabel29
-            // 
-            this.metroLabel29.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel29.AutoSize = true;
-            this.metroLabel29.Location = new System.Drawing.Point(3, 9);
-            this.metroLabel29.Name = "metroLabel29";
-            this.metroLabel29.Size = new System.Drawing.Size(129, 19);
-            this.metroLabel29.TabIndex = 18;
-            this.metroLabel29.Text = "TrackingFrameOffset";
-            // 
-            // trackingFrameOffsetTextBox
-            // 
-            this.trackingFrameOffsetTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.trackingFrameOffsetTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "trackingFrameOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.trackingFrameOffsetTextBox.Location = new System.Drawing.Point(138, 6);
-            this.trackingFrameOffsetTextBox.Name = "trackingFrameOffsetTextBox";
-            this.trackingFrameOffsetTextBox.Size = new System.Drawing.Size(102, 25);
-            this.trackingFrameOffsetTextBox.TabIndex = 27;
-            this.trackingFrameOffsetTextBox.Text = global::ALVR.Properties.Settings.Default.trackingFrameOffset;
-            // 
-            // saveTrackingFrameOffsetButton
-            // 
-            this.saveTrackingFrameOffsetButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.saveTrackingFrameOffsetButton.Location = new System.Drawing.Point(246, 6);
-            this.saveTrackingFrameOffsetButton.Name = "saveTrackingFrameOffsetButton";
-            this.saveTrackingFrameOffsetButton.Size = new System.Drawing.Size(75, 25);
-            this.saveTrackingFrameOffsetButton.TabIndex = 28;
-            this.saveTrackingFrameOffsetButton.Text = "Save";
-            this.saveTrackingFrameOffsetButton.Click += new System.EventHandler(this.saveTrackingFrameOffsetButton_Click);
-            // 
-            // metroLabel30
-            // 
-            this.metroLabel30.AutoSize = true;
-            this.metroLabel30.Location = new System.Drawing.Point(327, 0);
-            this.metroLabel30.Name = "metroLabel30";
-            this.metroLabel30.Size = new System.Drawing.Size(279, 38);
-            this.metroLabel30.TabIndex = 18;
-            this.metroLabel30.Text = "Try \"-1\" if you exceprience jerky head-tracking.\r\nPut \"0\" on if you have no probl" +
-    "em.";
-            // 
-            // flowLayoutPanel24
-            // 
-            this.flowLayoutPanel24.AutoSize = true;
-            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel24, 2);
-            this.flowLayoutPanel24.Controls.Add(this.metroLabel27);
-            this.flowLayoutPanel24.Controls.Add(this.connectCommandTextBox);
-            this.flowLayoutPanel24.Controls.Add(this.refConnectCommandButton);
-            this.flowLayoutPanel24.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel24.Location = new System.Drawing.Point(0, 311);
-            this.flowLayoutPanel24.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel24.Name = "flowLayoutPanel24";
-            this.flowLayoutPanel24.Size = new System.Drawing.Size(655, 31);
-            this.flowLayoutPanel24.TabIndex = 41;
-            // 
-            // metroLabel27
-            // 
-            this.metroLabel27.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel27.AutoSize = true;
-            this.metroLabel27.Location = new System.Drawing.Point(3, 6);
-            this.metroLabel27.Name = "metroLabel27";
-            this.metroLabel27.Size = new System.Drawing.Size(76, 19);
-            this.metroLabel27.TabIndex = 17;
-            this.metroLabel27.Text = "On connect";
-            // 
-            // connectCommandTextBox
-            // 
-            this.connectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "connectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.connectCommandTextBox.Location = new System.Drawing.Point(85, 3);
-            this.connectCommandTextBox.Name = "connectCommandTextBox";
-            this.connectCommandTextBox.Size = new System.Drawing.Size(351, 25);
-            this.connectCommandTextBox.TabIndex = 23;
-            this.connectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.connectCommand;
-            // 
-            // refConnectCommandButton
-            // 
-            this.refConnectCommandButton.Location = new System.Drawing.Point(442, 3);
-            this.refConnectCommandButton.Name = "refConnectCommandButton";
-            this.refConnectCommandButton.Size = new System.Drawing.Size(52, 25);
-            this.refConnectCommandButton.TabIndex = 24;
-            this.refConnectCommandButton.Text = "...";
-            this.refConnectCommandButton.Click += new System.EventHandler(this.refConnectCommandButton_Click);
-            // 
-            // metroLabel26
-            // 
-            this.metroLabel26.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel26.AutoSize = true;
-            this.metroLabel26.FontWeight = MetroFramework.MetroLabelWeight.Regular;
-            this.metroLabel26.Location = new System.Drawing.Point(3, 292);
-            this.metroLabel26.Name = "metroLabel26";
-            this.metroLabel26.Size = new System.Drawing.Size(101, 19);
-            this.metroLabel26.TabIndex = 3;
-            this.metroLabel26.Text = "Run command:";
-            // 
-            // flowLayoutPanel25
-            // 
-            this.flowLayoutPanel25.AutoSize = true;
-            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel25, 2);
-            this.flowLayoutPanel25.Controls.Add(this.metroLabel28);
-            this.flowLayoutPanel25.Controls.Add(this.disconnectCommandTextBox);
-            this.flowLayoutPanel25.Controls.Add(this.refDisconnectCommandButton);
-            this.flowLayoutPanel25.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel25.Location = new System.Drawing.Point(0, 342);
-            this.flowLayoutPanel25.Margin = new System.Windows.Forms.Padding(0);
-            this.flowLayoutPanel25.Name = "flowLayoutPanel25";
-            this.flowLayoutPanel25.Size = new System.Drawing.Size(655, 31);
-            this.flowLayoutPanel25.TabIndex = 42;
-            // 
-            // metroLabel28
-            // 
-            this.metroLabel28.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel28.AutoSize = true;
-            this.metroLabel28.Location = new System.Drawing.Point(3, 6);
-            this.metroLabel28.Name = "metroLabel28";
-            this.metroLabel28.Size = new System.Drawing.Size(92, 19);
-            this.metroLabel28.TabIndex = 17;
-            this.metroLabel28.Text = "On disconnect";
-            // 
-            // disconnectCommandTextBox
-            // 
-            this.disconnectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "disconnectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.disconnectCommandTextBox.Location = new System.Drawing.Point(101, 3);
-            this.disconnectCommandTextBox.Name = "disconnectCommandTextBox";
-            this.disconnectCommandTextBox.Size = new System.Drawing.Size(383, 25);
-            this.disconnectCommandTextBox.TabIndex = 25;
-            this.disconnectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.disconnectCommand;
-            // 
-            // refDisconnectCommandButton
-            // 
-            this.refDisconnectCommandButton.Location = new System.Drawing.Point(490, 3);
-            this.refDisconnectCommandButton.Name = "refDisconnectCommandButton";
-            this.refDisconnectCommandButton.Size = new System.Drawing.Size(52, 25);
-            this.refDisconnectCommandButton.TabIndex = 26;
-            this.refDisconnectCommandButton.Text = "...";
-            this.refDisconnectCommandButton.Click += new System.EventHandler(this.refDisconnectCommandButton_Click);
-            // 
-            // tableLayoutPanel3
-            // 
-            this.tableLayoutPanel3.AutoSize = true;
-            this.tableLayoutPanel3.ColumnCount = 1;
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel43, 0, 4);
-            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel37, 0, 3);
-            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel38, 0, 2);
-            this.tableLayoutPanel3.Controls.Add(this.flowLayoutPanel16, 0, 1);
-            this.tableLayoutPanel3.Controls.Add(this.metroLabel41, 0, 0);
-            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 13);
-            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 6;
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(405, 276);
-            this.tableLayoutPanel3.TabIndex = 44;
-            // 
-            // flowLayoutPanel43
-            // 
-            this.flowLayoutPanel43.AutoSize = true;
-            this.flowLayoutPanel43.Controls.Add(this.metroLabel40);
-            this.flowLayoutPanel43.Controls.Add(this.controllerRotationOffsetHelp);
-            this.flowLayoutPanel43.Controls.Add(this.numericUpDown4);
-            this.flowLayoutPanel43.Controls.Add(this.numericUpDown5);
-            this.flowLayoutPanel43.Controls.Add(this.numericUpDown6);
-            this.flowLayoutPanel43.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel43.Location = new System.Drawing.Point(3, 132);
-            this.flowLayoutPanel43.Name = "flowLayoutPanel43";
-            this.flowLayoutPanel43.Size = new System.Drawing.Size(399, 26);
-            this.flowLayoutPanel43.TabIndex = 39;
-            // 
-            // metroLabel40
-            // 
-            this.metroLabel40.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel40.AutoSize = true;
-            this.metroLabel40.Location = new System.Drawing.Point(3, 3);
-            this.metroLabel40.Name = "metroLabel40";
-            this.metroLabel40.Size = new System.Drawing.Size(210, 19);
-            this.metroLabel40.TabIndex = 0;
-            this.metroLabel40.Text = "Left rotation offset (pitch, yaw, roll)";
-            // 
-            // controllerRotationOffsetHelp
-            // 
-            this.controllerRotationOffsetHelp.AutoSize = true;
-            this.controllerRotationOffsetHelp.Location = new System.Drawing.Point(219, 0);
-            this.controllerRotationOffsetHelp.Name = "controllerRotationOffsetHelp";
-            this.controllerRotationOffsetHelp.Size = new System.Drawing.Size(15, 19);
-            this.controllerRotationOffsetHelp.TabIndex = 52;
-            this.controllerRotationOffsetHelp.Text = "?";
-            this.controllerRotationOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // numericUpDown4
-            // 
-            this.numericUpDown4.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPitchOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.numericUpDown4.Location = new System.Drawing.Point(240, 3);
-            this.numericUpDown4.Maximum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            0});
-            this.numericUpDown4.Minimum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            -2147483648});
-            this.numericUpDown4.Name = "numericUpDown4";
-            this.numericUpDown4.Size = new System.Drawing.Size(45, 20);
-            this.numericUpDown4.TabIndex = 54;
-            this.numericUpDown4.Value = global::ALVR.Properties.Settings.Default.leftControllerPitchOffset;
-            // 
-            // numericUpDown5
-            // 
-            this.numericUpDown5.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerYawOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.numericUpDown5.Location = new System.Drawing.Point(291, 3);
-            this.numericUpDown5.Maximum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            0});
-            this.numericUpDown5.Minimum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            -2147483648});
-            this.numericUpDown5.Name = "numericUpDown5";
-            this.numericUpDown5.Size = new System.Drawing.Size(45, 20);
-            this.numericUpDown5.TabIndex = 55;
-            this.numericUpDown5.Value = global::ALVR.Properties.Settings.Default.leftControllerYawOffset;
-            // 
-            // numericUpDown6
-            // 
-            this.numericUpDown6.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerRollOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.numericUpDown6.Location = new System.Drawing.Point(342, 3);
-            this.numericUpDown6.Maximum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            0});
-            this.numericUpDown6.Minimum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            -2147483648});
-            this.numericUpDown6.Name = "numericUpDown6";
-            this.numericUpDown6.Size = new System.Drawing.Size(45, 20);
-            this.numericUpDown6.TabIndex = 56;
-            this.numericUpDown6.Value = global::ALVR.Properties.Settings.Default.leftControllerRollOffset;
-            // 
-            // flowLayoutPanel37
-            // 
-            this.flowLayoutPanel37.AutoSize = true;
-            this.flowLayoutPanel37.Controls.Add(this.metroLabel39);
-            this.flowLayoutPanel37.Controls.Add(this.controllerPositionOffsetHelp);
-            this.flowLayoutPanel37.Controls.Add(this.numericUpDown1);
-            this.flowLayoutPanel37.Controls.Add(this.numericUpDown2);
-            this.flowLayoutPanel37.Controls.Add(this.numericUpDown3);
-            this.flowLayoutPanel37.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel37.Location = new System.Drawing.Point(3, 100);
-            this.flowLayoutPanel37.Name = "flowLayoutPanel37";
-            this.flowLayoutPanel37.Size = new System.Drawing.Size(399, 26);
-            this.flowLayoutPanel37.TabIndex = 38;
-            // 
-            // metroLabel39
-            // 
-            this.metroLabel39.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel39.AutoSize = true;
-            this.metroLabel39.Location = new System.Drawing.Point(3, 3);
-            this.metroLabel39.Name = "metroLabel39";
-            this.metroLabel39.Size = new System.Drawing.Size(159, 19);
-            this.metroLabel39.TabIndex = 0;
-            this.metroLabel39.Text = "Left position offset (x, y, z)";
-            // 
-            // controllerPositionOffsetHelp
-            // 
-            this.controllerPositionOffsetHelp.AutoSize = true;
-            this.controllerPositionOffsetHelp.Location = new System.Drawing.Point(168, 0);
-            this.controllerPositionOffsetHelp.Name = "controllerPositionOffsetHelp";
-            this.controllerPositionOffsetHelp.Size = new System.Drawing.Size(15, 19);
-            this.controllerPositionOffsetHelp.TabIndex = 52;
-            this.controllerPositionOffsetHelp.Text = "?";
-            this.controllerPositionOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // numericUpDown1
-            // 
-            this.numericUpDown1.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetX", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.numericUpDown1.DecimalPlaces = 3;
-            this.numericUpDown1.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            196608});
-            this.numericUpDown1.Location = new System.Drawing.Point(189, 3);
-            this.numericUpDown1.Maximum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            131072});
-            this.numericUpDown1.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.numericUpDown1.Name = "numericUpDown1";
-            this.numericUpDown1.Size = new System.Drawing.Size(55, 20);
-            this.numericUpDown1.TabIndex = 53;
-            this.numericUpDown1.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetX;
-            // 
-            // numericUpDown2
-            // 
-            this.numericUpDown2.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetY", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.numericUpDown2.DecimalPlaces = 3;
-            this.numericUpDown2.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            196608});
-            this.numericUpDown2.Location = new System.Drawing.Point(250, 3);
-            this.numericUpDown2.Maximum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            131072});
-            this.numericUpDown2.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.numericUpDown2.Name = "numericUpDown2";
-            this.numericUpDown2.Size = new System.Drawing.Size(55, 20);
-            this.numericUpDown2.TabIndex = 54;
-            this.numericUpDown2.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetY;
-            // 
-            // numericUpDown3
-            // 
-            this.numericUpDown3.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetZ", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.numericUpDown3.DecimalPlaces = 3;
-            this.numericUpDown3.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            196608});
-            this.numericUpDown3.Location = new System.Drawing.Point(311, 3);
-            this.numericUpDown3.Maximum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            131072});
-            this.numericUpDown3.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            -2147352576});
-            this.numericUpDown3.Name = "numericUpDown3";
-            this.numericUpDown3.Size = new System.Drawing.Size(55, 20);
-            this.numericUpDown3.TabIndex = 55;
-            this.numericUpDown3.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetZ;
-            // 
-            // flowLayoutPanel38
-            // 
-            this.flowLayoutPanel38.AutoSize = true;
-            this.flowLayoutPanel38.Controls.Add(this.metroLabel36);
-            this.flowLayoutPanel38.Controls.Add(this.handTrackingModeHelp);
-            this.flowLayoutPanel38.Controls.Add(this.controllerModeComboBox);
-            this.flowLayoutPanel38.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel38.Location = new System.Drawing.Point(3, 59);
-            this.flowLayoutPanel38.Name = "flowLayoutPanel38";
-            this.flowLayoutPanel38.Size = new System.Drawing.Size(399, 35);
-            this.flowLayoutPanel38.TabIndex = 0;
-            // 
-            // metroLabel36
-            // 
-            this.metroLabel36.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel36.AutoSize = true;
-            this.metroLabel36.Location = new System.Drawing.Point(3, 8);
-            this.metroLabel36.Name = "metroLabel36";
-            this.metroLabel36.Size = new System.Drawing.Size(129, 19);
-            this.metroLabel36.TabIndex = 0;
-            this.metroLabel36.Text = "Hand tracking mode";
-            // 
-            // handTrackingModeHelp
-            // 
-            this.handTrackingModeHelp.AutoSize = true;
-            this.handTrackingModeHelp.Location = new System.Drawing.Point(138, 0);
-            this.handTrackingModeHelp.Name = "handTrackingModeHelp";
-            this.handTrackingModeHelp.Size = new System.Drawing.Size(15, 19);
-            this.handTrackingModeHelp.TabIndex = 53;
-            this.handTrackingModeHelp.Text = "?";
-            this.handTrackingModeHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // controllerModeComboBox
-            // 
-            this.controllerModeComboBox.FormattingEnabled = true;
-            this.controllerModeComboBox.ItemHeight = 23;
-            this.controllerModeComboBox.Location = new System.Drawing.Point(159, 3);
-            this.controllerModeComboBox.Name = "controllerModeComboBox";
-            this.controllerModeComboBox.Size = new System.Drawing.Size(232, 29);
-            this.controllerModeComboBox.TabIndex = 1;
-            this.controllerModeComboBox.SelectedIndexChanged += new System.EventHandler(this.metroComboBox1_SelectedIndexChanged);
-            // 
-            // flowLayoutPanel16
-            // 
-            this.flowLayoutPanel16.AutoSize = true;
-            this.flowLayoutPanel16.Controls.Add(this.metroLabel12);
-            this.flowLayoutPanel16.Controls.Add(this.controllerPoseOffset);
-            this.flowLayoutPanel16.Controls.Add(this.metroButton1);
-            this.flowLayoutPanel16.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel16.Location = new System.Drawing.Point(3, 22);
-            this.flowLayoutPanel16.Name = "flowLayoutPanel16";
-            this.flowLayoutPanel16.Size = new System.Drawing.Size(399, 31);
-            this.flowLayoutPanel16.TabIndex = 37;
-            this.flowLayoutPanel16.WrapContents = false;
-            // 
-            // metroLabel12
-            // 
-            this.metroLabel12.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel12.AutoSize = true;
-            this.metroLabel12.Location = new System.Drawing.Point(3, 6);
-            this.metroLabel12.Name = "metroLabel12";
-            this.metroLabel12.Size = new System.Drawing.Size(102, 19);
-            this.metroLabel12.TabIndex = 20;
-            this.metroLabel12.Text = "Pose time offset";
-            this.metroLabel12.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // controllerPoseOffset
-            // 
-            this.controllerPoseOffset.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.controllerPoseOffset.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "controllerPoseOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.controllerPoseOffset.Location = new System.Drawing.Point(111, 6);
-            this.controllerPoseOffset.Name = "controllerPoseOffset";
-            this.controllerPoseOffset.Size = new System.Drawing.Size(52, 19);
-            this.controllerPoseOffset.TabIndex = 21;
-            this.controllerPoseOffset.Text = global::ALVR.Properties.Settings.Default.controllerPoseOffset;
-            this.controllerPoseOffset.Click += new System.EventHandler(this.controllerPoseOffset_Click);
-            // 
-            // metroButton1
-            // 
-            this.metroButton1.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroButton1.Location = new System.Drawing.Point(169, 3);
-            this.metroButton1.Name = "metroButton1";
-            this.metroButton1.Size = new System.Drawing.Size(75, 25);
-            this.metroButton1.TabIndex = 22;
-            this.metroButton1.Text = "Save";
-            this.metroButton1.Click += new System.EventHandler(this.metroButton1_Click);
-            // 
-            // metroLabel41
-            // 
-            this.metroLabel41.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.metroLabel41.AutoSize = true;
-            this.metroLabel41.FontWeight = MetroFramework.MetroLabelWeight.Regular;
-            this.metroLabel41.Location = new System.Drawing.Point(3, 0);
-            this.metroLabel41.Name = "metroLabel41";
-            this.metroLabel41.Size = new System.Drawing.Size(125, 19);
-            this.metroLabel41.TabIndex = 40;
-            this.metroLabel41.Text = "Controller settings:";
-            this.metroLabel41.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // videoTab
             // 
@@ -2746,6 +1947,799 @@
             this.defaultSoundDeviceCheckBox.UseVisualStyleBackColor = true;
             this.defaultSoundDeviceCheckBox.CheckedChanged += new System.EventHandler(this.defaultSoundDeviceCheckBox_CheckedChanged);
             // 
+            // otherTab
+            // 
+            this.otherTab.Controls.Add(this.tableLayoutPanel11);
+            this.otherTab.HorizontalScrollbarBarColor = true;
+            this.otherTab.HorizontalScrollbarSize = 0;
+            this.otherTab.Location = new System.Drawing.Point(4, 35);
+            this.otherTab.Name = "otherTab";
+            this.otherTab.Size = new System.Drawing.Size(655, 417);
+            this.otherTab.TabIndex = 7;
+            this.otherTab.Text = "Other";
+            this.otherTab.VerticalScrollbar = true;
+            this.otherTab.VerticalScrollbarBarColor = true;
+            this.otherTab.VerticalScrollbarSize = 0;
+            // 
+            // tableLayoutPanel11
+            // 
+            this.tableLayoutPanel11.BackColor = System.Drawing.SystemColors.Window;
+            this.tableLayoutPanel11.ColumnCount = 2;
+            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel45, 0, 0);
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel26, 1, 0);
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel17, 0, 6);
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel24, 0, 4);
+            this.tableLayoutPanel11.Controls.Add(this.metroLabel26, 0, 3);
+            this.tableLayoutPanel11.Controls.Add(this.flowLayoutPanel25, 0, 5);
+            this.tableLayoutPanel11.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel11.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel11.Name = "tableLayoutPanel11";
+            this.tableLayoutPanel11.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
+            this.tableLayoutPanel11.RowCount = 7;
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel11.Size = new System.Drawing.Size(655, 417);
+            this.tableLayoutPanel11.TabIndex = 37;
+            this.tableLayoutPanel11.Paint += new System.Windows.Forms.PaintEventHandler(this.tableLayoutPanel11_Paint);
+            // 
+            // flowLayoutPanel45
+            // 
+            this.flowLayoutPanel45.Controls.Add(this.metroLabel41);
+            this.flowLayoutPanel45.Controls.Add(this.flowLayoutPanel16);
+            this.flowLayoutPanel45.Controls.Add(this.flowLayoutPanel38);
+            this.flowLayoutPanel45.Controls.Add(this.flowLayoutPanel37);
+            this.flowLayoutPanel45.Controls.Add(this.flowLayoutPanel43);
+            this.flowLayoutPanel45.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel45.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flowLayoutPanel45.Location = new System.Drawing.Point(3, 13);
+            this.flowLayoutPanel45.Name = "flowLayoutPanel45";
+            this.flowLayoutPanel45.Size = new System.Drawing.Size(405, 276);
+            this.flowLayoutPanel45.TabIndex = 41;
+            // 
+            // metroLabel41
+            // 
+            this.metroLabel41.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel41.AutoSize = true;
+            this.metroLabel41.FontWeight = MetroFramework.MetroLabelWeight.Regular;
+            this.metroLabel41.Location = new System.Drawing.Point(3, 0);
+            this.metroLabel41.Name = "metroLabel41";
+            this.metroLabel41.Size = new System.Drawing.Size(125, 19);
+            this.metroLabel41.TabIndex = 40;
+            this.metroLabel41.Text = "Controller settings:";
+            this.metroLabel41.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // flowLayoutPanel16
+            // 
+            this.flowLayoutPanel16.Controls.Add(this.metroLabel12);
+            this.flowLayoutPanel16.Controls.Add(this.controllerPoseOffset);
+            this.flowLayoutPanel16.Controls.Add(this.metroButton1);
+            this.flowLayoutPanel16.Location = new System.Drawing.Point(3, 22);
+            this.flowLayoutPanel16.Name = "flowLayoutPanel16";
+            this.flowLayoutPanel16.Size = new System.Drawing.Size(399, 31);
+            this.flowLayoutPanel16.TabIndex = 37;
+            this.flowLayoutPanel16.WrapContents = false;
+            // 
+            // metroLabel12
+            // 
+            this.metroLabel12.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel12.AutoSize = true;
+            this.metroLabel12.Location = new System.Drawing.Point(3, 6);
+            this.metroLabel12.Name = "metroLabel12";
+            this.metroLabel12.Size = new System.Drawing.Size(102, 19);
+            this.metroLabel12.TabIndex = 20;
+            this.metroLabel12.Text = "Pose time offset";
+            this.metroLabel12.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // controllerPoseOffset
+            // 
+            this.controllerPoseOffset.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.controllerPoseOffset.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "controllerPoseOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.controllerPoseOffset.Location = new System.Drawing.Point(111, 6);
+            this.controllerPoseOffset.Name = "controllerPoseOffset";
+            this.controllerPoseOffset.Size = new System.Drawing.Size(52, 19);
+            this.controllerPoseOffset.TabIndex = 21;
+            this.controllerPoseOffset.Text = global::ALVR.Properties.Settings.Default.controllerPoseOffset;
+            this.controllerPoseOffset.Click += new System.EventHandler(this.controllerPoseOffset_Click);
+            // 
+            // metroButton1
+            // 
+            this.metroButton1.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroButton1.Location = new System.Drawing.Point(169, 3);
+            this.metroButton1.Name = "metroButton1";
+            this.metroButton1.Size = new System.Drawing.Size(75, 25);
+            this.metroButton1.TabIndex = 22;
+            this.metroButton1.Text = "Save";
+            this.metroButton1.Click += new System.EventHandler(this.metroButton1_Click);
+            // 
+            // flowLayoutPanel38
+            // 
+            this.flowLayoutPanel38.Controls.Add(this.metroLabel36);
+            this.flowLayoutPanel38.Controls.Add(this.handTrackingModeHelp);
+            this.flowLayoutPanel38.Controls.Add(this.controllerModeComboBox);
+            this.flowLayoutPanel38.Location = new System.Drawing.Point(3, 59);
+            this.flowLayoutPanel38.Name = "flowLayoutPanel38";
+            this.flowLayoutPanel38.Size = new System.Drawing.Size(399, 35);
+            this.flowLayoutPanel38.TabIndex = 0;
+            // 
+            // metroLabel36
+            // 
+            this.metroLabel36.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel36.AutoSize = true;
+            this.metroLabel36.Location = new System.Drawing.Point(3, 8);
+            this.metroLabel36.Name = "metroLabel36";
+            this.metroLabel36.Size = new System.Drawing.Size(129, 19);
+            this.metroLabel36.TabIndex = 0;
+            this.metroLabel36.Text = "Hand tracking mode";
+            // 
+            // handTrackingModeHelp
+            // 
+            this.handTrackingModeHelp.AutoSize = true;
+            this.handTrackingModeHelp.Location = new System.Drawing.Point(138, 0);
+            this.handTrackingModeHelp.Name = "handTrackingModeHelp";
+            this.handTrackingModeHelp.Size = new System.Drawing.Size(15, 19);
+            this.handTrackingModeHelp.TabIndex = 53;
+            this.handTrackingModeHelp.Text = "?";
+            this.handTrackingModeHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // controllerModeComboBox
+            // 
+            this.controllerModeComboBox.FormattingEnabled = true;
+            this.controllerModeComboBox.ItemHeight = 23;
+            this.controllerModeComboBox.Location = new System.Drawing.Point(159, 3);
+            this.controllerModeComboBox.Name = "controllerModeComboBox";
+            this.controllerModeComboBox.Size = new System.Drawing.Size(232, 29);
+            this.controllerModeComboBox.TabIndex = 1;
+            this.controllerModeComboBox.SelectedIndexChanged += new System.EventHandler(this.metroComboBox1_SelectedIndexChanged);
+            // 
+            // flowLayoutPanel37
+            // 
+            this.flowLayoutPanel37.Controls.Add(this.metroLabel39);
+            this.flowLayoutPanel37.Controls.Add(this.controllerPositionOffsetHelp);
+            this.flowLayoutPanel37.Controls.Add(this.numericUpDown1);
+            this.flowLayoutPanel37.Controls.Add(this.numericUpDown2);
+            this.flowLayoutPanel37.Controls.Add(this.numericUpDown3);
+            this.flowLayoutPanel37.Location = new System.Drawing.Point(3, 100);
+            this.flowLayoutPanel37.Name = "flowLayoutPanel37";
+            this.flowLayoutPanel37.Size = new System.Drawing.Size(399, 26);
+            this.flowLayoutPanel37.TabIndex = 38;
+            // 
+            // metroLabel39
+            // 
+            this.metroLabel39.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel39.AutoSize = true;
+            this.metroLabel39.Location = new System.Drawing.Point(3, 3);
+            this.metroLabel39.Name = "metroLabel39";
+            this.metroLabel39.Size = new System.Drawing.Size(159, 19);
+            this.metroLabel39.TabIndex = 0;
+            this.metroLabel39.Text = "Left position offset (x, y, z)";
+            // 
+            // controllerPositionOffsetHelp
+            // 
+            this.controllerPositionOffsetHelp.AutoSize = true;
+            this.controllerPositionOffsetHelp.Location = new System.Drawing.Point(168, 0);
+            this.controllerPositionOffsetHelp.Name = "controllerPositionOffsetHelp";
+            this.controllerPositionOffsetHelp.Size = new System.Drawing.Size(15, 19);
+            this.controllerPositionOffsetHelp.TabIndex = 52;
+            this.controllerPositionOffsetHelp.Text = "?";
+            this.controllerPositionOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // numericUpDown1
+            // 
+            this.numericUpDown1.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetX", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown1.DecimalPlaces = 3;
+            this.numericUpDown1.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            196608});
+            this.numericUpDown1.Location = new System.Drawing.Point(189, 3);
+            this.numericUpDown1.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.numericUpDown1.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.numericUpDown1.Name = "numericUpDown1";
+            this.numericUpDown1.Size = new System.Drawing.Size(55, 20);
+            this.numericUpDown1.TabIndex = 53;
+            this.numericUpDown1.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetX;
+            // 
+            // numericUpDown2
+            // 
+            this.numericUpDown2.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetY", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown2.DecimalPlaces = 3;
+            this.numericUpDown2.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            196608});
+            this.numericUpDown2.Location = new System.Drawing.Point(250, 3);
+            this.numericUpDown2.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.numericUpDown2.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.numericUpDown2.Name = "numericUpDown2";
+            this.numericUpDown2.Size = new System.Drawing.Size(55, 20);
+            this.numericUpDown2.TabIndex = 54;
+            this.numericUpDown2.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetY;
+            // 
+            // numericUpDown3
+            // 
+            this.numericUpDown3.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPositionOffsetZ", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown3.DecimalPlaces = 3;
+            this.numericUpDown3.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            196608});
+            this.numericUpDown3.Location = new System.Drawing.Point(311, 3);
+            this.numericUpDown3.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            131072});
+            this.numericUpDown3.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147352576});
+            this.numericUpDown3.Name = "numericUpDown3";
+            this.numericUpDown3.Size = new System.Drawing.Size(55, 20);
+            this.numericUpDown3.TabIndex = 55;
+            this.numericUpDown3.Value = global::ALVR.Properties.Settings.Default.leftControllerPositionOffsetZ;
+            // 
+            // flowLayoutPanel43
+            // 
+            this.flowLayoutPanel43.Controls.Add(this.metroLabel40);
+            this.flowLayoutPanel43.Controls.Add(this.controllerRotationOffsetHelp);
+            this.flowLayoutPanel43.Controls.Add(this.numericUpDown4);
+            this.flowLayoutPanel43.Controls.Add(this.numericUpDown5);
+            this.flowLayoutPanel43.Controls.Add(this.numericUpDown6);
+            this.flowLayoutPanel43.Location = new System.Drawing.Point(3, 132);
+            this.flowLayoutPanel43.Name = "flowLayoutPanel43";
+            this.flowLayoutPanel43.Size = new System.Drawing.Size(399, 26);
+            this.flowLayoutPanel43.TabIndex = 39;
+            // 
+            // metroLabel40
+            // 
+            this.metroLabel40.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel40.AutoSize = true;
+            this.metroLabel40.Location = new System.Drawing.Point(3, 3);
+            this.metroLabel40.Name = "metroLabel40";
+            this.metroLabel40.Size = new System.Drawing.Size(210, 19);
+            this.metroLabel40.TabIndex = 0;
+            this.metroLabel40.Text = "Left rotation offset (pitch, yaw, roll)";
+            // 
+            // controllerRotationOffsetHelp
+            // 
+            this.controllerRotationOffsetHelp.AutoSize = true;
+            this.controllerRotationOffsetHelp.Location = new System.Drawing.Point(219, 0);
+            this.controllerRotationOffsetHelp.Name = "controllerRotationOffsetHelp";
+            this.controllerRotationOffsetHelp.Size = new System.Drawing.Size(15, 19);
+            this.controllerRotationOffsetHelp.TabIndex = 52;
+            this.controllerRotationOffsetHelp.Text = "?";
+            this.controllerRotationOffsetHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // numericUpDown4
+            // 
+            this.numericUpDown4.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerPitchOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown4.Location = new System.Drawing.Point(240, 3);
+            this.numericUpDown4.Maximum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            0});
+            this.numericUpDown4.Minimum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            -2147483648});
+            this.numericUpDown4.Name = "numericUpDown4";
+            this.numericUpDown4.Size = new System.Drawing.Size(45, 20);
+            this.numericUpDown4.TabIndex = 54;
+            this.numericUpDown4.Value = global::ALVR.Properties.Settings.Default.leftControllerPitchOffset;
+            // 
+            // numericUpDown5
+            // 
+            this.numericUpDown5.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerYawOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown5.Location = new System.Drawing.Point(291, 3);
+            this.numericUpDown5.Maximum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            0});
+            this.numericUpDown5.Minimum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            -2147483648});
+            this.numericUpDown5.Name = "numericUpDown5";
+            this.numericUpDown5.Size = new System.Drawing.Size(45, 20);
+            this.numericUpDown5.TabIndex = 55;
+            this.numericUpDown5.Value = global::ALVR.Properties.Settings.Default.leftControllerYawOffset;
+            // 
+            // numericUpDown6
+            // 
+            this.numericUpDown6.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::ALVR.Properties.Settings.Default, "leftControllerRollOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericUpDown6.Location = new System.Drawing.Point(342, 3);
+            this.numericUpDown6.Maximum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            0});
+            this.numericUpDown6.Minimum = new decimal(new int[] {
+            90,
+            0,
+            0,
+            -2147483648});
+            this.numericUpDown6.Name = "numericUpDown6";
+            this.numericUpDown6.Size = new System.Drawing.Size(45, 20);
+            this.numericUpDown6.TabIndex = 56;
+            this.numericUpDown6.Value = global::ALVR.Properties.Settings.Default.leftControllerRollOffset;
+            // 
+            // flowLayoutPanel26
+            // 
+            this.flowLayoutPanel26.Controls.Add(this.onlySteamVRCheckBox);
+            this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel35);
+            this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel36);
+            this.flowLayoutPanel26.Controls.Add(this.force60HzCheckBox);
+            this.flowLayoutPanel26.Controls.Add(this.suppressFrameDropCheckBox);
+            this.flowLayoutPanel26.Controls.Add(this.disableThrottlingCheckBox);
+            this.flowLayoutPanel26.Controls.Add(this.disableController);
+            this.flowLayoutPanel26.Controls.Add(this.force3DOFCheckBox);
+            this.flowLayoutPanel26.Controls.Add(this.flowLayoutPanel15);
+            this.flowLayoutPanel26.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel26.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flowLayoutPanel26.Location = new System.Drawing.Point(414, 13);
+            this.flowLayoutPanel26.Name = "flowLayoutPanel26";
+            this.flowLayoutPanel26.Padding = new System.Windows.Forms.Padding(5, 0, 0, 0);
+            this.flowLayoutPanel26.Size = new System.Drawing.Size(238, 276);
+            this.flowLayoutPanel26.TabIndex = 40;
+            this.flowLayoutPanel26.WrapContents = false;
+            // 
+            // onlySteamVRCheckBox
+            // 
+            this.onlySteamVRCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.onlySteamVRCheckBox.AutoSize = true;
+            this.onlySteamVRCheckBox.Checked = global::ALVR.Properties.Settings.Default.onlySteamVR;
+            this.onlySteamVRCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "onlySteamVR", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.onlySteamVRCheckBox.Location = new System.Drawing.Point(8, 3);
+            this.onlySteamVRCheckBox.Name = "onlySteamVRCheckBox";
+            this.onlySteamVRCheckBox.Size = new System.Drawing.Size(221, 15);
+            this.onlySteamVRCheckBox.TabIndex = 29;
+            this.onlySteamVRCheckBox.Text = "Launch only SteamVR without Steam.";
+            this.onlySteamVRCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // flowLayoutPanel35
+            // 
+            this.flowLayoutPanel35.Controls.Add(this.steamAutoLaunch);
+            this.flowLayoutPanel35.Controls.Add(this.autoLaunchHelp);
+            this.flowLayoutPanel35.Location = new System.Drawing.Point(5, 21);
+            this.flowLayoutPanel35.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel35.Name = "flowLayoutPanel35";
+            this.flowLayoutPanel35.Size = new System.Drawing.Size(233, 21);
+            this.flowLayoutPanel35.TabIndex = 37;
+            // 
+            // steamAutoLaunch
+            // 
+            this.steamAutoLaunch.AutoSize = true;
+            this.steamAutoLaunch.Checked = global::ALVR.Properties.Settings.Default.steamAutolaunch;
+            this.steamAutoLaunch.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "steamAutolaunch", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.steamAutoLaunch.Location = new System.Drawing.Point(3, 3);
+            this.steamAutoLaunch.Name = "steamAutoLaunch";
+            this.steamAutoLaunch.Size = new System.Drawing.Size(206, 15);
+            this.steamAutoLaunch.TabIndex = 36;
+            this.steamAutoLaunch.Text = "Launch SteamVR on HMD connect";
+            this.steamAutoLaunch.UseVisualStyleBackColor = true;
+            // 
+            // autoLaunchHelp
+            // 
+            this.autoLaunchHelp.AutoSize = true;
+            this.autoLaunchHelp.Location = new System.Drawing.Point(215, 0);
+            this.autoLaunchHelp.Name = "autoLaunchHelp";
+            this.autoLaunchHelp.Size = new System.Drawing.Size(15, 19);
+            this.autoLaunchHelp.TabIndex = 37;
+            this.autoLaunchHelp.Text = "?";
+            this.autoLaunchHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // flowLayoutPanel36
+            // 
+            this.flowLayoutPanel36.AutoSize = true;
+            this.flowLayoutPanel36.Controls.Add(this.launchMinimized);
+            this.flowLayoutPanel36.Location = new System.Drawing.Point(5, 42);
+            this.flowLayoutPanel36.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel36.Name = "flowLayoutPanel36";
+            this.flowLayoutPanel36.Size = new System.Drawing.Size(157, 21);
+            this.flowLayoutPanel36.TabIndex = 38;
+            // 
+            // launchMinimized
+            // 
+            this.launchMinimized.AutoSize = true;
+            this.launchMinimized.Checked = global::ALVR.Properties.Settings.Default.launchMinimized;
+            this.launchMinimized.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "launchMinimized", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.launchMinimized.Location = new System.Drawing.Point(3, 3);
+            this.launchMinimized.Name = "launchMinimized";
+            this.launchMinimized.Size = new System.Drawing.Size(151, 15);
+            this.launchMinimized.TabIndex = 0;
+            this.launchMinimized.Text = "Launch ALVR minimized";
+            this.launchMinimized.UseVisualStyleBackColor = true;
+            // 
+            // force60HzCheckBox
+            // 
+            this.force60HzCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.force60HzCheckBox.AutoSize = true;
+            this.force60HzCheckBox.Checked = global::ALVR.Properties.Settings.Default.force60Hz;
+            this.force60HzCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force60Hz", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.force60HzCheckBox.Location = new System.Drawing.Point(8, 66);
+            this.force60HzCheckBox.Name = "force60HzCheckBox";
+            this.force60HzCheckBox.Size = new System.Drawing.Size(81, 15);
+            this.force60HzCheckBox.TabIndex = 31;
+            this.force60HzCheckBox.Text = "Force 60Hz";
+            this.force60HzCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // suppressFrameDropCheckBox
+            // 
+            this.suppressFrameDropCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.suppressFrameDropCheckBox.AutoSize = true;
+            this.suppressFrameDropCheckBox.Checked = global::ALVR.Properties.Settings.Default.suppressFrameDrop;
+            this.suppressFrameDropCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "suppressFrameDrop", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.suppressFrameDropCheckBox.Location = new System.Drawing.Point(8, 87);
+            this.suppressFrameDropCheckBox.Name = "suppressFrameDropCheckBox";
+            this.suppressFrameDropCheckBox.Size = new System.Drawing.Size(132, 15);
+            this.suppressFrameDropCheckBox.TabIndex = 30;
+            this.suppressFrameDropCheckBox.Text = "Suppress frame drop";
+            this.suppressFrameDropCheckBox.UseVisualStyleBackColor = true;
+            this.suppressFrameDropCheckBox.CheckedChanged += new System.EventHandler(this.suppressFrameDropCheckBox_CheckedChanged);
+            // 
+            // disableThrottlingCheckBox
+            // 
+            this.disableThrottlingCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.disableThrottlingCheckBox.AutoSize = true;
+            this.disableThrottlingCheckBox.Checked = global::ALVR.Properties.Settings.Default.disableThrottling;
+            this.disableThrottlingCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableThrottling", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.disableThrottlingCheckBox.Location = new System.Drawing.Point(8, 108);
+            this.disableThrottlingCheckBox.Name = "disableThrottlingCheckBox";
+            this.disableThrottlingCheckBox.Size = new System.Drawing.Size(142, 15);
+            this.disableThrottlingCheckBox.TabIndex = 32;
+            this.disableThrottlingCheckBox.Text = "Disable send throttling";
+            this.disableThrottlingCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // disableController
+            // 
+            this.disableController.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.disableController.AutoSize = true;
+            this.disableController.Checked = global::ALVR.Properties.Settings.Default.disableController;
+            this.disableController.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "disableController", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.disableController.Location = new System.Drawing.Point(8, 129);
+            this.disableController.Name = "disableController";
+            this.disableController.Size = new System.Drawing.Size(115, 15);
+            this.disableController.TabIndex = 33;
+            this.disableController.Text = "Disable controller";
+            this.disableController.UseVisualStyleBackColor = true;
+            // 
+            // force3DOFCheckBox
+            // 
+            this.force3DOFCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.force3DOFCheckBox.AutoSize = true;
+            this.force3DOFCheckBox.Checked = global::ALVR.Properties.Settings.Default.force3DOF;
+            this.force3DOFCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "force3DOF", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.force3DOFCheckBox.Location = new System.Drawing.Point(8, 150);
+            this.force3DOFCheckBox.Name = "force3DOFCheckBox";
+            this.force3DOFCheckBox.Size = new System.Drawing.Size(84, 15);
+            this.force3DOFCheckBox.TabIndex = 34;
+            this.force3DOFCheckBox.Text = "Force 3DOF";
+            this.force3DOFCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // flowLayoutPanel15
+            // 
+            this.flowLayoutPanel15.AutoSize = true;
+            this.flowLayoutPanel15.Controls.Add(this.aggressiveKeyframeResend);
+            this.flowLayoutPanel15.Controls.Add(this.aggressiveKeyframeResendHelp);
+            this.flowLayoutPanel15.Location = new System.Drawing.Point(5, 168);
+            this.flowLayoutPanel15.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel15.Name = "flowLayoutPanel15";
+            this.flowLayoutPanel15.Size = new System.Drawing.Size(194, 21);
+            this.flowLayoutPanel15.TabIndex = 35;
+            // 
+            // aggressiveKeyframeResend
+            // 
+            this.aggressiveKeyframeResend.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.aggressiveKeyframeResend.AutoSize = true;
+            this.aggressiveKeyframeResend.Checked = global::ALVR.Properties.Settings.Default.aggressiveKeyframeResend;
+            this.aggressiveKeyframeResend.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "aggressiveKeyframeResend", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.aggressiveKeyframeResend.Location = new System.Drawing.Point(3, 3);
+            this.aggressiveKeyframeResend.Name = "aggressiveKeyframeResend";
+            this.aggressiveKeyframeResend.Size = new System.Drawing.Size(170, 15);
+            this.aggressiveKeyframeResend.TabIndex = 35;
+            this.aggressiveKeyframeResend.Text = "Aggressive keyframe resend";
+            this.aggressiveKeyframeResend.UseVisualStyleBackColor = true;
+            // 
+            // aggressiveKeyframeResendHelp
+            // 
+            this.aggressiveKeyframeResendHelp.AutoSize = true;
+            this.aggressiveKeyframeResendHelp.BackColor = System.Drawing.SystemColors.ControlDark;
+            this.aggressiveKeyframeResendHelp.FontSize = MetroFramework.MetroLabelSize.Small;
+            this.aggressiveKeyframeResendHelp.Location = new System.Drawing.Point(179, 0);
+            this.aggressiveKeyframeResendHelp.Name = "aggressiveKeyframeResendHelp";
+            this.aggressiveKeyframeResendHelp.Size = new System.Drawing.Size(12, 15);
+            this.aggressiveKeyframeResendHelp.Style = MetroFramework.MetroColorStyle.Blue;
+            this.aggressiveKeyframeResendHelp.TabIndex = 0;
+            this.aggressiveKeyframeResendHelp.Text = "?";
+            this.aggressiveKeyframeResendHelp.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // flowLayoutPanel17
+            // 
+            this.flowLayoutPanel17.AutoSize = true;
+            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel17, 2);
+            this.flowLayoutPanel17.Controls.Add(this.metroLabel29);
+            this.flowLayoutPanel17.Controls.Add(this.trackingFrameOffsetTextBox);
+            this.flowLayoutPanel17.Controls.Add(this.saveTrackingFrameOffsetButton);
+            this.flowLayoutPanel17.Controls.Add(this.metroLabel30);
+            this.flowLayoutPanel17.Location = new System.Drawing.Point(3, 376);
+            this.flowLayoutPanel17.Name = "flowLayoutPanel17";
+            this.flowLayoutPanel17.Size = new System.Drawing.Size(609, 38);
+            this.flowLayoutPanel17.TabIndex = 0;
+            this.flowLayoutPanel17.WrapContents = false;
+            // 
+            // metroLabel29
+            // 
+            this.metroLabel29.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel29.AutoSize = true;
+            this.metroLabel29.Location = new System.Drawing.Point(3, 9);
+            this.metroLabel29.Name = "metroLabel29";
+            this.metroLabel29.Size = new System.Drawing.Size(129, 19);
+            this.metroLabel29.TabIndex = 18;
+            this.metroLabel29.Text = "TrackingFrameOffset";
+            // 
+            // trackingFrameOffsetTextBox
+            // 
+            this.trackingFrameOffsetTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.trackingFrameOffsetTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "trackingFrameOffset", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.trackingFrameOffsetTextBox.Location = new System.Drawing.Point(138, 6);
+            this.trackingFrameOffsetTextBox.Name = "trackingFrameOffsetTextBox";
+            this.trackingFrameOffsetTextBox.Size = new System.Drawing.Size(102, 25);
+            this.trackingFrameOffsetTextBox.TabIndex = 27;
+            this.trackingFrameOffsetTextBox.Text = global::ALVR.Properties.Settings.Default.trackingFrameOffset;
+            // 
+            // saveTrackingFrameOffsetButton
+            // 
+            this.saveTrackingFrameOffsetButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.saveTrackingFrameOffsetButton.Location = new System.Drawing.Point(246, 6);
+            this.saveTrackingFrameOffsetButton.Name = "saveTrackingFrameOffsetButton";
+            this.saveTrackingFrameOffsetButton.Size = new System.Drawing.Size(75, 25);
+            this.saveTrackingFrameOffsetButton.TabIndex = 28;
+            this.saveTrackingFrameOffsetButton.Text = "Save";
+            this.saveTrackingFrameOffsetButton.Click += new System.EventHandler(this.saveTrackingFrameOffsetButton_Click);
+            // 
+            // metroLabel30
+            // 
+            this.metroLabel30.AutoSize = true;
+            this.metroLabel30.Location = new System.Drawing.Point(327, 0);
+            this.metroLabel30.Name = "metroLabel30";
+            this.metroLabel30.Size = new System.Drawing.Size(279, 38);
+            this.metroLabel30.TabIndex = 18;
+            this.metroLabel30.Text = "Try \"-1\" if you exceprience jerky head-tracking.\r\nPut \"0\" on if you have no probl" +
+    "em.";
+            // 
+            // flowLayoutPanel24
+            // 
+            this.flowLayoutPanel24.AutoSize = true;
+            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel24, 2);
+            this.flowLayoutPanel24.Controls.Add(this.metroLabel27);
+            this.flowLayoutPanel24.Controls.Add(this.connectCommandTextBox);
+            this.flowLayoutPanel24.Controls.Add(this.refConnectCommandButton);
+            this.flowLayoutPanel24.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel24.Location = new System.Drawing.Point(0, 311);
+            this.flowLayoutPanel24.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel24.Name = "flowLayoutPanel24";
+            this.flowLayoutPanel24.Size = new System.Drawing.Size(655, 31);
+            this.flowLayoutPanel24.TabIndex = 41;
+            // 
+            // metroLabel27
+            // 
+            this.metroLabel27.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel27.AutoSize = true;
+            this.metroLabel27.Location = new System.Drawing.Point(3, 6);
+            this.metroLabel27.Name = "metroLabel27";
+            this.metroLabel27.Size = new System.Drawing.Size(76, 19);
+            this.metroLabel27.TabIndex = 17;
+            this.metroLabel27.Text = "On connect";
+            // 
+            // connectCommandTextBox
+            // 
+            this.connectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "connectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.connectCommandTextBox.Location = new System.Drawing.Point(85, 3);
+            this.connectCommandTextBox.Name = "connectCommandTextBox";
+            this.connectCommandTextBox.Size = new System.Drawing.Size(351, 25);
+            this.connectCommandTextBox.TabIndex = 23;
+            this.connectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.connectCommand;
+            // 
+            // refConnectCommandButton
+            // 
+            this.refConnectCommandButton.Location = new System.Drawing.Point(442, 3);
+            this.refConnectCommandButton.Name = "refConnectCommandButton";
+            this.refConnectCommandButton.Size = new System.Drawing.Size(52, 25);
+            this.refConnectCommandButton.TabIndex = 24;
+            this.refConnectCommandButton.Text = "...";
+            this.refConnectCommandButton.Click += new System.EventHandler(this.refConnectCommandButton_Click);
+            // 
+            // metroLabel26
+            // 
+            this.metroLabel26.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel26.AutoSize = true;
+            this.metroLabel26.FontWeight = MetroFramework.MetroLabelWeight.Regular;
+            this.metroLabel26.Location = new System.Drawing.Point(3, 292);
+            this.metroLabel26.Name = "metroLabel26";
+            this.metroLabel26.Size = new System.Drawing.Size(101, 19);
+            this.metroLabel26.TabIndex = 3;
+            this.metroLabel26.Text = "Run command:";
+            // 
+            // flowLayoutPanel25
+            // 
+            this.flowLayoutPanel25.AutoSize = true;
+            this.tableLayoutPanel11.SetColumnSpan(this.flowLayoutPanel25, 2);
+            this.flowLayoutPanel25.Controls.Add(this.metroLabel28);
+            this.flowLayoutPanel25.Controls.Add(this.disconnectCommandTextBox);
+            this.flowLayoutPanel25.Controls.Add(this.refDisconnectCommandButton);
+            this.flowLayoutPanel25.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel25.Location = new System.Drawing.Point(0, 342);
+            this.flowLayoutPanel25.Margin = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel25.Name = "flowLayoutPanel25";
+            this.flowLayoutPanel25.Size = new System.Drawing.Size(655, 31);
+            this.flowLayoutPanel25.TabIndex = 42;
+            // 
+            // metroLabel28
+            // 
+            this.metroLabel28.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.metroLabel28.AutoSize = true;
+            this.metroLabel28.Location = new System.Drawing.Point(3, 6);
+            this.metroLabel28.Name = "metroLabel28";
+            this.metroLabel28.Size = new System.Drawing.Size(92, 19);
+            this.metroLabel28.TabIndex = 17;
+            this.metroLabel28.Text = "On disconnect";
+            // 
+            // disconnectCommandTextBox
+            // 
+            this.disconnectCommandTextBox.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::ALVR.Properties.Settings.Default, "disconnectCommand", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.disconnectCommandTextBox.Location = new System.Drawing.Point(101, 3);
+            this.disconnectCommandTextBox.Name = "disconnectCommandTextBox";
+            this.disconnectCommandTextBox.Size = new System.Drawing.Size(383, 25);
+            this.disconnectCommandTextBox.TabIndex = 25;
+            this.disconnectCommandTextBox.Text = global::ALVR.Properties.Settings.Default.disconnectCommand;
+            // 
+            // refDisconnectCommandButton
+            // 
+            this.refDisconnectCommandButton.Location = new System.Drawing.Point(490, 3);
+            this.refDisconnectCommandButton.Name = "refDisconnectCommandButton";
+            this.refDisconnectCommandButton.Size = new System.Drawing.Size(52, 25);
+            this.refDisconnectCommandButton.TabIndex = 26;
+            this.refDisconnectCommandButton.Text = "...";
+            this.refDisconnectCommandButton.Click += new System.EventHandler(this.refDisconnectCommandButton_Click);
+            // 
+            // presetsTab
+            // 
+            this.presetsTab.Controls.Add(this.tableLayoutPanel2);
+            this.presetsTab.HorizontalScrollbarBarColor = true;
+            this.presetsTab.HorizontalScrollbarSize = 0;
+            this.presetsTab.Location = new System.Drawing.Point(4, 35);
+            this.presetsTab.Name = "presetsTab";
+            this.presetsTab.Size = new System.Drawing.Size(655, 417);
+            this.presetsTab.TabIndex = 9;
+            this.presetsTab.Text = "Presets";
+            this.presetsTab.VerticalScrollbarBarColor = true;
+            this.presetsTab.VerticalScrollbarSize = 0;
+            // 
+            // tableLayoutPanel2
+            // 
+            this.tableLayoutPanel2.BackColor = System.Drawing.SystemColors.Window;
+            this.tableLayoutPanel2.ColumnCount = 2;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel44, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.metroLabel38, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel42, 1, 0);
+            this.tableLayoutPanel2.Controls.Add(this.metroLabel42, 0, 1);
+            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            this.tableLayoutPanel2.Padding = new System.Windows.Forms.Padding(0, 10, 0, 0);
+            this.tableLayoutPanel2.RowCount = 3;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(655, 417);
+            this.tableLayoutPanel2.TabIndex = 9;
+            // 
+            // flowLayoutPanel44
+            // 
+            this.flowLayoutPanel44.AutoSize = true;
+            this.flowLayoutPanel44.Controls.Add(this.fixBoneworksControllersButton);
+            this.flowLayoutPanel44.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel44.Location = new System.Drawing.Point(103, 50);
+            this.flowLayoutPanel44.Name = "flowLayoutPanel44";
+            this.flowLayoutPanel44.Size = new System.Drawing.Size(549, 31);
+            this.flowLayoutPanel44.TabIndex = 29;
+            // 
+            // fixBoneworksControllersButton
+            // 
+            this.fixBoneworksControllersButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.fixBoneworksControllersButton.Location = new System.Drawing.Point(3, 3);
+            this.fixBoneworksControllersButton.Name = "fixBoneworksControllersButton";
+            this.fixBoneworksControllersButton.Size = new System.Drawing.Size(163, 25);
+            this.fixBoneworksControllersButton.TabIndex = 23;
+            this.fixBoneworksControllersButton.Text = "Boneworks controllers offset";
+            this.fixBoneworksControllersButton.Click += new System.EventHandler(this.fixBoneworksControllersButton_Click);
+            // 
+            // metroLabel38
+            // 
+            this.metroLabel38.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.metroLabel38.AutoSize = true;
+            this.metroLabel38.Location = new System.Drawing.Point(46, 19);
+            this.metroLabel38.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.metroLabel38.Name = "metroLabel38";
+            this.metroLabel38.Size = new System.Drawing.Size(54, 19);
+            this.metroLabel38.TabIndex = 27;
+            this.metroLabel38.Text = "General";
+            // 
+            // flowLayoutPanel42
+            // 
+            this.flowLayoutPanel42.AutoSize = true;
+            this.flowLayoutPanel42.Controls.Add(this.revertToDefaultButton);
+            this.flowLayoutPanel42.Controls.Add(this.defaultControllerOffsetsButton);
+            this.flowLayoutPanel42.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel42.Location = new System.Drawing.Point(103, 13);
+            this.flowLayoutPanel42.Name = "flowLayoutPanel42";
+            this.flowLayoutPanel42.Size = new System.Drawing.Size(549, 31);
+            this.flowLayoutPanel42.TabIndex = 26;
+            // 
+            // revertToDefaultButton
+            // 
+            this.revertToDefaultButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.revertToDefaultButton.Location = new System.Drawing.Point(3, 3);
+            this.revertToDefaultButton.Name = "revertToDefaultButton";
+            this.revertToDefaultButton.Size = new System.Drawing.Size(163, 25);
+            this.revertToDefaultButton.TabIndex = 23;
+            this.revertToDefaultButton.Text = "Revert all settings to default";
+            this.revertToDefaultButton.Click += new System.EventHandler(this.revertToDefaultButton_Click);
+            // 
+            // defaultControllerOffsetsButton
+            // 
+            this.defaultControllerOffsetsButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.defaultControllerOffsetsButton.Location = new System.Drawing.Point(172, 3);
+            this.defaultControllerOffsetsButton.Name = "defaultControllerOffsetsButton";
+            this.defaultControllerOffsetsButton.Size = new System.Drawing.Size(175, 25);
+            this.defaultControllerOffsetsButton.TabIndex = 24;
+            this.defaultControllerOffsetsButton.Text = "Set controller offsets to default";
+            this.defaultControllerOffsetsButton.Click += new System.EventHandler(this.defaultControllerOffsetsButton_Click);
+            // 
+            // metroLabel42
+            // 
+            this.metroLabel42.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.metroLabel42.AutoSize = true;
+            this.metroLabel42.Location = new System.Drawing.Point(63, 56);
+            this.metroLabel42.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.metroLabel42.Name = "metroLabel42";
+            this.metroLabel42.Size = new System.Drawing.Size(37, 19);
+            this.metroLabel42.TabIndex = 28;
+            this.metroLabel42.Text = "Fixes";
+            // 
             // debugTab
             // 
             this.debugTab.Controls.Add(this.tableLayoutPanel14);
@@ -3224,44 +3218,6 @@
             this.tableLayoutPanel8.ResumeLayout(false);
             this.tableLayoutPanel8.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.statDataGridView)).EndInit();
-            this.presetsTab.ResumeLayout(false);
-            this.tableLayoutPanel2.ResumeLayout(false);
-            this.tableLayoutPanel2.PerformLayout();
-            this.flowLayoutPanel44.ResumeLayout(false);
-            this.flowLayoutPanel42.ResumeLayout(false);
-            this.otherTab.ResumeLayout(false);
-            this.tableLayoutPanel11.ResumeLayout(false);
-            this.tableLayoutPanel11.PerformLayout();
-            this.flowLayoutPanel26.ResumeLayout(false);
-            this.flowLayoutPanel26.PerformLayout();
-            this.flowLayoutPanel35.ResumeLayout(false);
-            this.flowLayoutPanel35.PerformLayout();
-            this.flowLayoutPanel36.ResumeLayout(false);
-            this.flowLayoutPanel36.PerformLayout();
-            this.flowLayoutPanel15.ResumeLayout(false);
-            this.flowLayoutPanel15.PerformLayout();
-            this.flowLayoutPanel17.ResumeLayout(false);
-            this.flowLayoutPanel17.PerformLayout();
-            this.flowLayoutPanel24.ResumeLayout(false);
-            this.flowLayoutPanel24.PerformLayout();
-            this.flowLayoutPanel25.ResumeLayout(false);
-            this.flowLayoutPanel25.PerformLayout();
-            this.tableLayoutPanel3.ResumeLayout(false);
-            this.tableLayoutPanel3.PerformLayout();
-            this.flowLayoutPanel43.ResumeLayout(false);
-            this.flowLayoutPanel43.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown4)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown5)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown6)).EndInit();
-            this.flowLayoutPanel37.ResumeLayout(false);
-            this.flowLayoutPanel37.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).EndInit();
-            this.flowLayoutPanel38.ResumeLayout(false);
-            this.flowLayoutPanel38.PerformLayout();
-            this.flowLayoutPanel16.ResumeLayout(false);
-            this.flowLayoutPanel16.PerformLayout();
             this.videoTab.ResumeLayout(false);
             this.videoTab.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
@@ -3317,6 +3273,44 @@
             this.flowLayoutPanel13.PerformLayout();
             this.flowLayoutPanel14.ResumeLayout(false);
             this.flowLayoutPanel14.PerformLayout();
+            this.otherTab.ResumeLayout(false);
+            this.tableLayoutPanel11.ResumeLayout(false);
+            this.tableLayoutPanel11.PerformLayout();
+            this.flowLayoutPanel45.ResumeLayout(false);
+            this.flowLayoutPanel45.PerformLayout();
+            this.flowLayoutPanel16.ResumeLayout(false);
+            this.flowLayoutPanel16.PerformLayout();
+            this.flowLayoutPanel38.ResumeLayout(false);
+            this.flowLayoutPanel38.PerformLayout();
+            this.flowLayoutPanel37.ResumeLayout(false);
+            this.flowLayoutPanel37.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).EndInit();
+            this.flowLayoutPanel43.ResumeLayout(false);
+            this.flowLayoutPanel43.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown4)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown5)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown6)).EndInit();
+            this.flowLayoutPanel26.ResumeLayout(false);
+            this.flowLayoutPanel26.PerformLayout();
+            this.flowLayoutPanel35.ResumeLayout(false);
+            this.flowLayoutPanel35.PerformLayout();
+            this.flowLayoutPanel36.ResumeLayout(false);
+            this.flowLayoutPanel36.PerformLayout();
+            this.flowLayoutPanel15.ResumeLayout(false);
+            this.flowLayoutPanel15.PerformLayout();
+            this.flowLayoutPanel17.ResumeLayout(false);
+            this.flowLayoutPanel17.PerformLayout();
+            this.flowLayoutPanel24.ResumeLayout(false);
+            this.flowLayoutPanel24.PerformLayout();
+            this.flowLayoutPanel25.ResumeLayout(false);
+            this.flowLayoutPanel25.PerformLayout();
+            this.presetsTab.ResumeLayout(false);
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            this.flowLayoutPanel44.ResumeLayout(false);
+            this.flowLayoutPanel42.ResumeLayout(false);
             this.debugTab.ResumeLayout(false);
             this.tableLayoutPanel14.ResumeLayout(false);
             this.tableLayoutPanel14.PerformLayout();
@@ -3539,7 +3533,6 @@
         private MetroFramework.Controls.MetroButton revertToDefaultButton;
         private MetroFramework.Controls.MetroLabel metroLabel38;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel42;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel43;
         private MetroFramework.Controls.MetroLabel metroLabel40;
         private MetroFramework.Controls.MetroLabel controllerRotationOffsetHelp;
@@ -3560,6 +3553,8 @@
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel44;
         private MetroFramework.Controls.MetroButton fixBoneworksControllersButton;
         private MetroFramework.Controls.MetroLabel metroLabel42;
+        private MetroFramework.Controls.MetroButton defaultControllerOffsetsButton;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel45;
     }
 }
 

--- a/ALVR/Launcher.cs
+++ b/ALVR/Launcher.cs
@@ -193,6 +193,14 @@ namespace ALVR
 
             toolTip1.SetToolTip(this.autoLaunchHelp, "Launch Steam / SteamVR as soon as a headset is connected");
 
+            toolTip1.SetToolTip(this.handTrackingModeHelp, "This is just a proof of concept and it is not usable for most games that require buttons");
+
+            toolTip1.SetToolTip(this.controllerPositionOffsetHelp, "Position offset in meters for the left controller.\n" +
+                "For the right controller, x value is mirrored");
+
+            toolTip1.SetToolTip(this.controllerRotationOffsetHelp, "Rotation offset in degrees for the left controller.\n" +
+                "For the right controller, yaw and roll values are mirrored");
+
 
 
 

--- a/ALVR/Launcher.cs
+++ b/ALVR/Launcher.cs
@@ -1040,5 +1040,11 @@ namespace ALVR
             }
             SaveSettings();
         }
+
+        private void revertToDefaultButton_Click(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.Reset();
+            LoadSettings();
+        }
     }
 }

--- a/ALVR/Launcher.cs
+++ b/ALVR/Launcher.cs
@@ -1061,6 +1061,18 @@ namespace ALVR
             Properties.Settings.Default.leftControllerPositionOffsetY = 0;
             Properties.Settings.Default.leftControllerPositionOffsetZ = 0;
             Properties.Settings.Default.leftControllerPitchOffset = -20;
+            Properties.Settings.Default.leftControllerYawOffset = 0;
+            Properties.Settings.Default.leftControllerRollOffset = 0;
+        }
+
+        private void defaultControllerOffsetsButton_Click(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.leftControllerPositionOffsetX = (decimal)-0.007;
+            Properties.Settings.Default.leftControllerPositionOffsetY = (decimal)0.005;
+            Properties.Settings.Default.leftControllerPositionOffsetZ = (decimal)-0.053;
+            Properties.Settings.Default.leftControllerPitchOffset = 36;
+            Properties.Settings.Default.leftControllerYawOffset = 0;
+            Properties.Settings.Default.leftControllerRollOffset = 0;
         }
     }
 }

--- a/ALVR/Launcher.cs
+++ b/ALVR/Launcher.cs
@@ -1054,5 +1054,13 @@ namespace ALVR
             Properties.Settings.Default.Reset();
             LoadSettings();
         }
+
+        private void fixBoneworksControllersButton_Click(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.leftControllerPositionOffsetX = 0;
+            Properties.Settings.Default.leftControllerPositionOffsetY = 0;
+            Properties.Settings.Default.leftControllerPositionOffsetZ = 0;
+            Properties.Settings.Default.leftControllerPitchOffset = -20;
+        }
     }
 }

--- a/ALVR/Properties/Settings.Designer.cs
+++ b/ALVR/Properties/Settings.Designer.cs
@@ -597,5 +597,77 @@ namespace ALVR.Properties {
                 this["sharpening"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("-0.007")]
+        public decimal leftControllerPositionOffsetX {
+            get {
+                return ((decimal)(this["leftControllerPositionOffsetX"]));
+            }
+            set {
+                this["leftControllerPositionOffsetX"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0.005")]
+        public decimal leftControllerPositionOffsetY {
+            get {
+                return ((decimal)(this["leftControllerPositionOffsetY"]));
+            }
+            set {
+                this["leftControllerPositionOffsetY"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("-0.053")]
+        public decimal leftControllerPositionOffsetZ {
+            get {
+                return ((decimal)(this["leftControllerPositionOffsetZ"]));
+            }
+            set {
+                this["leftControllerPositionOffsetZ"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("36")]
+        public decimal leftControllerPitchOffset {
+            get {
+                return ((decimal)(this["leftControllerPitchOffset"]));
+            }
+            set {
+                this["leftControllerPitchOffset"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public decimal leftControllerYawOffset {
+            get {
+                return ((decimal)(this["leftControllerYawOffset"]));
+            }
+            set {
+                this["leftControllerYawOffset"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public decimal leftControllerRollOffset {
+            get {
+                return ((decimal)(this["leftControllerRollOffset"]));
+            }
+            set {
+                this["leftControllerRollOffset"] = value;
+            }
+        }
     }
 }

--- a/ALVR/Properties/Settings.settings
+++ b/ALVR/Properties/Settings.settings
@@ -146,5 +146,23 @@
     <Setting Name="sharpening" Type="System.Decimal" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="leftControllerPositionOffsetX" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">-0.007</Value>
+    </Setting>
+    <Setting Name="leftControllerPositionOffsetY" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">0.005</Value>
+    </Setting>
+    <Setting Name="leftControllerPositionOffsetZ" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">-0.053</Value>
+    </Setting>
+    <Setting Name="leftControllerPitchOffset" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">36</Value>
+    </Setting>
+    <Setting Name="leftControllerYawOffset" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="leftControllerRollOffset" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ALVR/ServerConfig.cs
+++ b/ALVR/ServerConfig.cs
@@ -249,6 +249,13 @@ namespace ALVR
                 driverConfig.trackingFrameOffset = Utils.ParseInt(c.trackingFrameOffset);
                 driverConfig.controllerPoseOffset = Utils.ParseFloat(c.controllerPoseOffset);
 
+                driverConfig.leftControllerPositionOffsetX = (float)c.leftControllerPositionOffsetX;
+                driverConfig.leftControllerPositionOffsetY = (float)c.leftControllerPositionOffsetY;
+                driverConfig.leftControllerPositionOffsetZ = (float)c.leftControllerPositionOffsetZ;
+                driverConfig.leftControllerPitchOffset = (float)c.leftControllerPitchOffset;
+                driverConfig.leftControllerYawOffset = (float)c.leftControllerYawOffset;
+                driverConfig.leftControllerRollOffset = (float)c.leftControllerRollOffset;
+
                 driverConfig.foveationMode = c.foveationMode;
                 driverConfig.foveationStrength = c.foveationStrength / 100f;
                 driverConfig.foveationShape = 1.5f;

--- a/alvr_server/OvrController.cpp
+++ b/alvr_server/OvrController.cpp
@@ -7,19 +7,25 @@ OvrController::OvrController(bool isLeftHand, int index)
 	, m_unObjectId(vr::k_unTrackedDeviceIndexInvalid)
 	, m_index(index)
 {
+	double rightHandSignFlip = isLeftHand ? 1. : -1.;
+
 	memset(&m_pose, 0, sizeof(m_pose));
 	m_pose.poseIsValid = true;
 	m_pose.result = vr::TrackingResult_Running_OK;
 	m_pose.deviceIsConnected = true;
 
 	//controller is rotated and translated, prepare pose
-	double rotation[3] = { 0.0, 0.0, 36 * M_PI / 180 };
+	double rotation[3] = {
+		Settings::Instance().m_leftControllerRotationOffset[1] * DEG_TO_RAD * rightHandSignFlip,
+		Settings::Instance().m_leftControllerRotationOffset[2] * DEG_TO_RAD * rightHandSignFlip,
+		Settings::Instance().m_leftControllerRotationOffset[0] * DEG_TO_RAD,
+	};
 	m_pose.qDriverFromHeadRotation = EulerAngleToQuaternion(rotation);
 
 	vr::HmdVector3d_t offset;
-	offset.v[0] =	0;
-	offset.v[1] =	0.009;
-	offset.v[2] = -0.053;
+	offset.v[0] = Settings::Instance().m_leftControllerPositionOffset[0] * rightHandSignFlip;
+	offset.v[1] = Settings::Instance().m_leftControllerPositionOffset[1];
+	offset.v[2] = Settings::Instance().m_leftControllerPositionOffset[2];
 
 	vr::HmdVector3d_t offetRes = vrmath::quaternionRotateVector(m_pose.qDriverFromHeadRotation, offset, false);
 

--- a/alvr_server/Settings.cpp
+++ b/alvr_server/Settings.cpp
@@ -152,12 +152,19 @@ void Settings::Load()
 		m_trackingFrameOffset = (int32_t)v.get(k_pch_Settings_TrackingFrameOffset_Int32).get<int64_t>();
 		m_controllerPoseOffset = (double)v.get(k_pch_Settings_controllerPoseOffset_Float).get<double>();
 
+		m_leftControllerPositionOffset[0] = v.get(k_pch_Settings_leftControllerPositionOffsetX_Float).get<double>();
+		m_leftControllerPositionOffset[1] = v.get(k_pch_Settings_leftControllerPositionOffsetY_Float).get<double>();
+		m_leftControllerPositionOffset[2] = v.get(k_pch_Settings_leftControllerPositionOffsetZ_Float).get<double>();
+		m_leftControllerRotationOffset[0] = v.get(k_pch_Settings_leftControllerPitchOffset_Float).get<double>();
+		m_leftControllerRotationOffset[1] = v.get(k_pch_Settings_leftControllerYawOffset_Float).get<double>();
+		m_leftControllerRotationOffset[2] = v.get(k_pch_Settings_leftControllerRollOffset_Float).get<double>();
+
 		m_foveationMode = (FOVEATION_MODE)v.get(k_pch_Settings_foveationMode_Int32).get<int64_t>();
 		m_foveationStrength = (float)v.get(k_pch_Settings_foveationStrength_Float).get<double>();
 		m_foveationShape = (float)v.get(k_pch_Settings_foveationShape_Float).get<double>();
 		m_foveationVerticalOffset = (float)v.get(k_pch_Settings_foveationVerticalOffset_Float).get<double>();
 
-		m_enableColorCorrection = (FOVEATION_MODE)v.get(k_pch_Settings_EnableColorCorrection_Bool).get<bool>();
+		m_enableColorCorrection = v.get(k_pch_Settings_EnableColorCorrection_Bool).get<bool>();
 		m_brightness = (float)v.get(k_pch_Settings_Brightness_Float).get<double>();
 		m_contrast = (float)v.get(k_pch_Settings_Contrast_Float).get<double>();
 		m_saturation = (float)v.get(k_pch_Settings_Saturation_Float).get<double>();

--- a/alvr_server/Settings.h
+++ b/alvr_server/Settings.h
@@ -87,6 +87,13 @@ static const char * const k_pch_Settings_OffsetPosX_Float = "offsetPosX";
 static const char * const k_pch_Settings_OffsetPosY_Float = "offsetPosY";
 static const char * const k_pch_Settings_OffsetPosZ_Float = "offsetPosZ";
 
+static const char* const k_pch_Settings_leftControllerPositionOffsetX_Float = "leftControllerPositionOffsetX";
+static const char* const k_pch_Settings_leftControllerPositionOffsetY_Float = "leftControllerPositionOffsetY";
+static const char* const k_pch_Settings_leftControllerPositionOffsetZ_Float = "leftControllerPositionOffsetZ";
+static const char* const k_pch_Settings_leftControllerPitchOffset_Float = "leftControllerPitchOffset";
+static const char* const k_pch_Settings_leftControllerYawOffset_Float = "leftControllerYawOffset";
+static const char* const k_pch_Settings_leftControllerRollOffset_Float = "leftControllerRollOffset";
+
 static const char * const k_pch_Settings_controllerPoseOffset_Float = "controllerPoseOffset";
 
 static const char * const k_pch_Settings_foveationMode_Int32 = "foveationMode";
@@ -232,6 +239,9 @@ public:
 
 	float m_OffsetPos[3];
 	bool m_EnableOffsetPos;
+
+	double m_leftControllerPositionOffset[3];
+	double m_leftControllerRotationOffset[3];
 
 	int32_t m_causePacketLoss;
 

--- a/alvr_server/Utils.h
+++ b/alvr_server/Utils.h
@@ -21,6 +21,7 @@
 extern HINSTANCE g_hInstance;
 
 const uint64_t US_TO_MS = 1000;
+const float DEG_TO_RAD = M_PI / 180.;
 extern uint64_t gPerformanceCounterFrequency;
 
 // Get elapsed time in us from Unix Epoch


### PR DESCRIPTION
* Add "Presets" tab with "Revert settings to default", "Boneworks controllers fix" and "Set default controller offsets;
* Add configurable controller position and rotation offset + "Other" tab UI refactoring.

I lost at least 1h and an half trying to understand why on the numericUpDowns that I added, when positioned in certain places and when I set a negative value, close and reopen ALVR, the value was clamped to zero. Then I restarted Visual Studio and the sucessive builds didn't had this bug anymore. Also sometimes the tabs get shuffled and the merge diff becomes unreadable. TBH we should scrap WinForms and use WPF or UWP but I have no time for this.

@JackD83 For fixes for other games, please tell me what to add, or else merge this and add them yourself.