### PR TITLE
Add scaling of 66% for AMD VCE <=2

### DIFF
--- a/ALVR/ServerConfig.cs
+++ b/ALVR/ServerConfig.cs
@@ -17,7 +17,7 @@ namespace ALVR
         private static readonly string APP_FILEMAPPING_NAME = "ALVR_DRIVER_FILEMAPPING_0B124897-7730-4B84-AA32-088E9B92851F";
 
         public static readonly int DEFAULT_SCALE_INDEX = 3; // 100%
-        public static readonly int[] supportedScales = { 25, 50, 75, 100, 125, 150, 175, 200 };
+        public static readonly int[] supportedScales = { 25, 50, 66, 75, 100, 125, 150, 175, 200 };
 
         public static readonly int DEFAULT_REFRESHRATE = 72;
         public static readonly int DEFAULT_WIDTH = 2432;


### PR DESCRIPTION
AMD VCE 1 and 2 can only encode up to 1920px wide content. This is 66.6666% scaling on the Quest (2880px wide).