### PR TITLE
Activate Profile High and Level 5.1 for H264

### DIFF
--- a/alvr_server/VideoEncoderVCE.cpp
+++ b/alvr_server/VideoEncoderVCE.cpp
@@ -45,8 +45,8 @@ AMFTextureEncoder::AMFTextureEncoder(const amf::AMFContextPtr &amfContext
 		m_amfEncoder->SetProperty(AMF_VIDEO_ENCODER_FRAMESIZE, ::AMFConstructSize(width, height));
 		m_amfEncoder->SetProperty(AMF_VIDEO_ENCODER_FRAMERATE, ::AMFConstructRate(frameRateIn, 1));
 
-		//m_amfEncoder->SetProperty(AMF_VIDEO_ENCODER_PROFILE, AMF_VIDEO_ENCODER_PROFILE_HIGH);
-		//m_amfEncoder->SetProperty(AMF_VIDEO_ENCODER_PROFILE_LEVEL, 51);
+		m_amfEncoder->SetProperty(AMF_VIDEO_ENCODER_PROFILE, AMF_VIDEO_ENCODER_PROFILE_HIGH);
+		m_amfEncoder->SetProperty(AMF_VIDEO_ENCODER_PROFILE_LEVEL, 51);
 	}
 	else
 	{


### PR DESCRIPTION
According to https://github.com/obsproject/obs-amd-encoder/wiki/Hardware-Support these features are available from VCE 1.0.
This might need verification. I could test for VCE 2.0.