### PR TITLE
fix format specification syntax of wchar.

### DIFF
--- a/alvr_server/AudioCapture.cpp
+++ b/alvr_server/AudioCapture.cpp
@@ -213,7 +213,7 @@ void AudioCapture::list_devices(std::vector<AudioEndPointDescriptor> &deviceList
 	}
 	LogDriver("Active render endpoints found: %u", count);
 
-	LogDriver("DefaultDevice:%s ID:%s", defaultDescriptor.GetName().c_str(), defaultDescriptor.GetId().c_str());
+	LogDriver("DefaultDevice:%ls ID:%ls", defaultDescriptor.GetName().c_str(), defaultDescriptor.GetId().c_str());
 
 	for (UINT i = 0; i < count; i++) {
 		ComPtr<IMMDevice> pMMDevice;
@@ -231,7 +231,7 @@ void AudioCapture::list_devices(std::vector<AudioEndPointDescriptor> &deviceList
 		}
 		deviceList.push_back(descriptor);
 
-		LogDriver("Device%u:%s ID:%s", i, descriptor.GetName().c_str(), descriptor.GetId().c_str());
+		LogDriver("Device%u:%ls ID:%ls", i, descriptor.GetName().c_str(), descriptor.GetId().c_str());
 	}
 }
 
@@ -254,7 +254,7 @@ void AudioCapture::OpenDevice(const std::wstring &id) {
 
 	hr = pMMDeviceEnumerator->GetDevice(id.c_str(), &m_pMMDevice);
 	if (FAILED(hr)) {
-		throw MakeException(L"Could not find a device id %s. hr = 0x%08x", id.c_str(), hr);
+		throw MakeException(L"Could not find a device id %ls. hr = 0x%08x", id.c_str(), hr);
 	}
 }
 
@@ -262,7 +262,7 @@ void AudioCapture::Start(const std::wstring &id) {
 	CoInitialize(NULL);
 
 	OpenDevice(id);
-	LogDriver("Audio device: %s", AudioEndPointDescriptor::GetDeviceName(m_pMMDevice).c_str());
+	LogDriver("Audio device: %ls", AudioEndPointDescriptor::GetDeviceName(m_pMMDevice).c_str());
 
 	m_hThread.Set(CreateThread(
 		NULL, 0,
@@ -281,7 +281,7 @@ void AudioCapture::Start(const std::wstring &id) {
 	);
 
 	if (WAIT_OBJECT_0 + 1 == waitResult) {
-		throw MakeException(L"Thread aborted before starting to loopback capture. message=%s", m_errorMessage.c_str());
+		throw MakeException(L"Thread aborted before starting to loopback capture. message=%ls", m_errorMessage.c_str());
 	}
 
 	if (WAIT_OBJECT_0 != waitResult) {
@@ -312,7 +312,7 @@ void AudioCapture::Shutdown() {
 		MMIOINFO mi = { 0 };
 		MMIOHandle file(mmioOpenW((LPWSTR)Settings::Instance().GetAudioOutput().c_str(), &mi, MMIO_READWRITE));
 		if (!file.IsValid()) {
-			throw MakeException(L"mmioOpen(\"%s\", ...) failed. wErrorRet == %u", Settings::Instance().GetAudioOutput().c_str(), mi.wErrorRet);
+			throw MakeException(L"mmioOpen(\"%ls\", ...) failed. wErrorRet == %u", Settings::Instance().GetAudioOutput().c_str(), mi.wErrorRet);
 		}
 
 		// descend into the RIFF/WAVE chunk
@@ -466,7 +466,7 @@ void AudioCapture::LoopbackCapture() {
 		));
 
 		if (!hFile.IsValid()) {
-			LogDriver("Error on open audio debug output. mmioOpen(\"%s\", ...) failed. wErrorRet == %u", Settings::Instance().GetAudioOutput().c_str(), mi.wErrorRet);
+			LogDriver("Error on open audio debug output. mmioOpen(\"%ls\", ...) failed. wErrorRet == %u", Settings::Instance().GetAudioOutput().c_str(), mi.wErrorRet);
 		}
 		try {
 			WriteWaveHeader(hFile.Get(), pwfx, &ckRIFF, &ckData);

--- a/alvr_server/FrameRender.cpp
+++ b/alvr_server/FrameRender.cpp
@@ -52,7 +52,7 @@ bool FrameRender::Startup()
 
 	HRESULT hr = m_pD3DRender->GetDevice()->CreateRenderTargetView(compositionTexture.Get(), NULL, &m_pRenderTargetView);
 	if (FAILED(hr)) {
-		LogDriver("CreateRenderTargetView %p %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("CreateRenderTargetView %p %ls", hr, GetErrorStr(hr).c_str());
 		return false;
 	}
 
@@ -72,7 +72,7 @@ bool FrameRender::Startup()
 	descDepth.MiscFlags = 0;
 	hr = m_pD3DRender->GetDevice()->CreateTexture2D(&descDepth, nullptr, &m_pDepthStencil);
 	if (FAILED(hr)) {
-		LogDriver("CreateTexture2D %p %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("CreateTexture2D %p %ls", hr, GetErrorStr(hr).c_str());
 		return false;
 	}
 
@@ -85,7 +85,7 @@ bool FrameRender::Startup()
 	descDSV.Texture2D.MipSlice = 0;
 	hr = m_pD3DRender->GetDevice()->CreateDepthStencilView(m_pDepthStencil.Get(), &descDSV, &m_pDepthStencilView);
 	if (FAILED(hr)) {
-		LogDriver("CreateDepthStencilView %p %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("CreateDepthStencilView %p %ls", hr, GetErrorStr(hr).c_str());
 		return false;
 	}
 
@@ -112,7 +112,7 @@ bool FrameRender::Startup()
 
 	hr = m_pD3DRender->GetDevice()->CreateVertexShader((const DWORD*)&vshader[0], vshader.size(), NULL, &m_pVertexShader);
 	if (FAILED(hr)) {
-		LogDriver("CreateVertexShader %p %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("CreateVertexShader %p %ls", hr, GetErrorStr(hr).c_str());
 		return false;
 	}
 
@@ -124,7 +124,7 @@ bool FrameRender::Startup()
 
 	hr = m_pD3DRender->GetDevice()->CreatePixelShader((const DWORD*)&pshader[0], pshader.size(), NULL, &m_pPixelShader);
 	if (FAILED(hr)) {
-		LogDriver("CreatePixelShader %p %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("CreatePixelShader %p %ls", hr, GetErrorStr(hr).c_str());
 		return false;
 	}
 
@@ -146,7 +146,7 @@ bool FrameRender::Startup()
 	hr = m_pD3DRender->GetDevice()->CreateInputLayout(layout, numElements, &vshader[0],
 		vshader.size(), &m_pVertexLayout);
 	if (FAILED(hr)) {
-		LogDriver("CreateInputLayout %p %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("CreateInputLayout %p %ls", hr, GetErrorStr(hr).c_str());
 		return false;
 	}
 
@@ -169,7 +169,7 @@ bool FrameRender::Startup()
 
 	hr = m_pD3DRender->GetDevice()->CreateBuffer(&bd, NULL, &m_pVertexBuffer);
 	if (FAILED(hr)) {
-		LogDriver("CreateBuffer 1 %p %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("CreateBuffer 1 %p %ls", hr, GetErrorStr(hr).c_str());
 		return false;
 	}
 
@@ -202,7 +202,7 @@ bool FrameRender::Startup()
 
 	hr = m_pD3DRender->GetDevice()->CreateBuffer(&bd, &InitData, &m_pIndexBuffer);
 	if (FAILED(hr)) {
-		LogDriver("CreateBuffer 2 %p %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("CreateBuffer 2 %p %ls", hr, GetErrorStr(hr).c_str());
 		return false;
 	}
 
@@ -224,7 +224,7 @@ bool FrameRender::Startup()
 	sampDesc.MaxLOD = D3D11_FLOAT32_MAX;
 	hr = m_pD3DRender->GetDevice()->CreateSamplerState(&sampDesc, &m_pSamplerLinear);
 	if (FAILED(hr)) {
-		LogDriver("CreateSamplerState %p %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("CreateSamplerState %p %ls", hr, GetErrorStr(hr).c_str());
 		return false;
 	}
 
@@ -266,7 +266,7 @@ bool FrameRender::Startup()
 
 	hr = m_pD3DRender->GetDevice()->CreateBlendState(&BlendDesc, &m_pBlendStateFirst);
 	if (FAILED(hr)) {
-		LogDriver("CreateBlendState %p %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("CreateBlendState %p %ls", hr, GetErrorStr(hr).c_str());
 		return false;
 	}
 
@@ -286,7 +286,7 @@ bool FrameRender::Startup()
 
 	hr = m_pD3DRender->GetDevice()->CreateBlendState(&BlendDesc, &m_pBlendState);
 	if (FAILED(hr)) {
-		LogDriver("CreateBlendState %p %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("CreateBlendState %p %ls", hr, GetErrorStr(hr).c_str());
 		return false;
 	}
 
@@ -412,12 +412,12 @@ bool FrameRender::RenderFrame(ID3D11Texture2D *pTexture[][2], vr::VRTextureBound
 
 		HRESULT hr = m_pD3DRender->GetDevice()->CreateShaderResourceView(textures[0], &SRVDesc, pShaderResourceView[0].ReleaseAndGetAddressOf());
 		if (FAILED(hr)) {
-			LogDriver("CreateShaderResourceView %p %s", hr, GetErrorStr(hr).c_str());
+			LogDriver("CreateShaderResourceView %p %ls", hr, GetErrorStr(hr).c_str());
 			return false;
 		}
 		hr = m_pD3DRender->GetDevice()->CreateShaderResourceView(textures[1], &SRVDesc, pShaderResourceView[1].ReleaseAndGetAddressOf());
 		if (FAILED(hr)) {
-			LogDriver("CreateShaderResourceView %p %s", hr, GetErrorStr(hr).c_str());
+			LogDriver("CreateShaderResourceView %p %ls", hr, GetErrorStr(hr).c_str());
 			return false;
 		}
 		
@@ -456,7 +456,7 @@ bool FrameRender::RenderFrame(ID3D11Texture2D *pTexture[][2], vr::VRTextureBound
 		D3D11_MAPPED_SUBRESOURCE mapped = { 0 };
 		hr = m_pD3DRender->GetContext()->Map(m_pVertexBuffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
 		if (FAILED(hr)) {
-			LogDriver("Map %p %s", hr, GetErrorStr(hr).c_str());
+			LogDriver("Map %p %ls", hr, GetErrorStr(hr).c_str());
 			return false;
 		}
 		memcpy(mapped.pData, vertices, sizeof(vertices));
@@ -594,9 +594,9 @@ void FrameRender::CreateResourceTexture()
 	HRESULT hr = DirectX::CreateWICTextureFromMemory(m_pD3DRender->GetDevice(), (uint8_t *)&texture[0], texture.size(),
 		&m_recenterTexture, &m_recenterResourceView);
 	if (!m_recenterTexture) {
-		LogDriver("Failed to create recenter texture. %d %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("Failed to create recenter texture. %d %ls", hr, GetErrorStr(hr).c_str());
 	}else if (!m_recenterResourceView) {
-		LogDriver("Failed to create recenter resource view. %d %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("Failed to create recenter resource view. %d %ls", hr, GetErrorStr(hr).c_str());
 	}
 
 	if (!ReadBinaryResource(texture, IDR_MESSAGE_BG_TEXTURE)) {
@@ -607,10 +607,10 @@ void FrameRender::CreateResourceTexture()
 	hr = DirectX::CreateWICTextureFromMemory(m_pD3DRender->GetDevice(), (uint8_t *)&texture[0], texture.size(),
 		&m_messageBGTexture, &m_messageBGResourceView);
 	if (!m_messageBGTexture) {
-		LogDriver("Failed to create message_bg texture. %d %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("Failed to create message_bg texture. %d %ls", hr, GetErrorStr(hr).c_str());
 	}
 	else if (!m_messageBGResourceView) {
-		LogDriver("Failed to create message_bg resource view. %d %s", hr, GetErrorStr(hr).c_str());
+		LogDriver("Failed to create message_bg resource view. %d %ls", hr, GetErrorStr(hr).c_str());
 	}
 }
 

--- a/alvr_server/Logger.cpp
+++ b/alvr_server/Logger.cpp
@@ -107,8 +107,8 @@ static void OutputCrashLog(PEXCEPTION_POINTERS pExceptionPtrs) {
 		return;
 	}
 
-	fwprintf(fp, L"Exception: %s\n", lastException.c_str());
-	fwprintf(fp, L"OSVer: %s\n", GetWindowsOSVersion().c_str());
+	fwprintf(fp, L"Exception: %ls\n", lastException.c_str());
+	fwprintf(fp, L"OSVer: %ls\n", GetWindowsOSVersion().c_str());
 	fwprintf(fp, L"Module: %p\n", g_hInstance);
 	fwprintf(fp, L"========== Startup Log ==========\n");
 

--- a/alvr_server/OvrDirectModeComponent.cpp
+++ b/alvr_server/OvrDirectModeComponent.cpp
@@ -269,7 +269,7 @@ void OvrDirectModeComponent::Present(vr::SharedTextureHandle_t syncTexture)
 			HRESULT hr = pKeyedMutex->AcquireSync(0, 10);
 			if (hr != S_OK)
 			{
-				LogDriver("[VDispDvr] ACQUIRESYNC FAILED!!! hr=%d %p %s", hr, hr, GetErrorStr(hr).c_str());
+				LogDriver("[VDispDvr] ACQUIRESYNC FAILED!!! hr=%d %p %ls", hr, hr, GetErrorStr(hr).c_str());
 				pKeyedMutex->Release();
 				return;
 			}
@@ -346,7 +346,7 @@ void OvrDirectModeComponent::CopyTexture(uint32_t layerCount) {
 			LogDriver("Writing Debug DDS. m_LastReferencedFrameIndex=%llu layer=%d/%d", 0, i, layerCount);
 			_snwprintf_s(buf, sizeof(buf), L"%hs\\debug-%llu-%d-%d.dds", Settings::Instance().m_DebugOutputDir.c_str(), m_submitFrameIndex, i, layerCount);
 			HRESULT hr = DirectX::SaveDDSTextureToFile(m_pD3DRender->GetContext(), pTexture[i][0], buf);
-			LogDriver("Writing Debug DDS: End hr=%p %s", hr, GetErrorStr(hr).c_str());
+			LogDriver("Writing Debug DDS: End hr=%p %ls", hr, GetErrorStr(hr).c_str());
 		}
 		Settings::Instance().m_captureLayerDDSTrigger = false;
 	}

--- a/alvr_server/OvrHMD.cpp
+++ b/alvr_server/OvrHMD.cpp
@@ -156,8 +156,8 @@ OvrHmd::OvrHmd(std::shared_ptr<ClientConnection> listener)
 			return vr::VRInitError_Driver_Failed;
 		}
 
-		LogDriver("Using %s as primary graphics adapter.", m_adapterName.c_str());
-		LogDriver("OSVer: %s", GetWindowsOSVersion().c_str());
+		LogDriver("Using %ls as primary graphics adapter.", m_adapterName.c_str());
+		LogDriver("OSVer: %ls", GetWindowsOSVersion().c_str());
 
 		// Spin up a separate thread to handle the overlapped encoding/transmit step.
 		m_encoder = std::make_shared<CEncoder>();

--- a/alvr_server/Poller.cpp
+++ b/alvr_server/Poller.cpp
@@ -27,7 +27,7 @@ int Poller::Do() {
 	memcpy(&mWriteFDs, &mOrgWriteFDs, sizeof(fd_set));
 	int ret = select(0, &mReadFDs, &mWriteFDs, NULL, &timeout);
 	if (ret == SOCKET_ERROR) {
-		LogDriver("select error : %d %s", WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
+		LogDriver("select error : %d %ls", WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
 		return ret;
 	}
 	Log("Poller::Do(). Select done. %d", ret);
@@ -73,7 +73,7 @@ bool Poller::BindQueueSocket()
 {
 	mQueueSocket = socket(AF_INET, SOCK_DGRAM, 0);
 	if (mQueueSocket == INVALID_SOCKET) {
-		FatalLog("Poller::BindQueueSocket socket creation error: %d %s", WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
+		FatalLog("Poller::BindQueueSocket socket creation error: %d %ls", WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
 		return false;
 	}
 
@@ -90,7 +90,7 @@ bool Poller::BindQueueSocket()
 
 	int ret = bind(mQueueSocket, (sockaddr *)&addr, sizeof(addr));
 	if (ret != 0) {
-		FatalLog("Poller::BindQueueSocket bind error : %d %s", WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
+		FatalLog("Poller::BindQueueSocket bind error : %d %ls", WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
 		return false;
 	}
 
@@ -98,7 +98,7 @@ bool Poller::BindQueueSocket()
 	int len = sizeof(mQueueAddr);
 	ret = getsockname(mQueueSocket, (sockaddr *)&mQueueAddr, &len);
 	if (ret != 0) {
-		FatalLog("Poller::BindQueueSocket getsockname error : %d %hs", WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
+		FatalLog("Poller::BindQueueSocket getsockname error : %d %ls", WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
 		return false;
 	}
 	char buf[30];

--- a/alvr_server/UdpSocket.cpp
+++ b/alvr_server/UdpSocket.cpp
@@ -106,7 +106,7 @@ bool UdpSocket::BindSocket()
 {
 	mSocket = socket(AF_INET, SOCK_DGRAM, 0);
 	if (mSocket == INVALID_SOCKET) {
-		FatalLog("UdpSocket::BindSocket socket creation error: %d %s", WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
+		FatalLog("UdpSocket::BindSocket socket creation error: %d %ls", WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
 		return false;
 	}
 
@@ -123,7 +123,7 @@ bool UdpSocket::BindSocket()
 
 	int ret = bind(mSocket, (sockaddr *)&addr, sizeof(addr));
 	if (ret != 0) {
-		FatalLog("UdpSocket::BindSocket bind error : Address=%hs:%d %d %s", mHost.c_str(), mPort, WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
+		FatalLog("UdpSocket::BindSocket bind error : Address=%hs:%d %d %ls", mHost.c_str(), mPort, WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
 		return false;
 	}
 	LogDriver("UdpSocket::BindSocket successfully bound to %hs:%d", mHost.c_str(), mPort);
@@ -139,7 +139,7 @@ bool UdpSocket::DoSend(char * buf, int len)
 		return true;
 	}
 	if (WSAGetLastError() != WSAEWOULDBLOCK) {
-		LogDriver("UdpSocket::DoSend() Error on sendto. %d %s", WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
+		LogDriver("UdpSocket::DoSend() Error on sendto. %d %ls", WSAGetLastError(), GetErrorStr(WSAGetLastError()).c_str());
 	}
 	return false;
 }


### PR DESCRIPTION
resolve #171 
When ALVR.exe call driver_alvr_server.dll's GetSoundDevices function, internal LogDriver function failed to execute because format specification syntax of wchar was incorrect.
I fixed format specification of wchar in alvr_server project.