### PR TITLE
Document situation of unsupported GPU via crash report, closes #130

### DIFF
--- a/CrashReport/CrashReport.cs
+++ b/CrashReport/CrashReport.cs
@@ -16,25 +16,10 @@ namespace CrashReport
         {
             InitializeComponent();
 
-            textBox1.Text = UserFriendlyError(Environment.GetCommandLineArgs()[1]);
+            textBox1.Text = Environment.GetCommandLineArgs()[1];
             textBox1.Select(0, 0);
 
             CenterToScreen();
-        }
-
-        private string UserFriendlyError(string error)
-        {
-            if (error == null)
-            {
-                return null;
-            }
-
-            if (error.Contains("Failed to initialize CEncoder. All VideoEncoder are not available. VCE: AMF Error 4. m_amfContext->InitDX11(m_d3dRender->GetDevice()), NVENC: Failed to load nvcuda.dll. Please check if NVIDIA graphic driver is installed."))
-            {
-                return error + " *** This error has been reported to occur when you are running an unsupported GPU, for example an integrated GPU of a CPU, as a main GPU of your system. Please ensure the cable of your monitor is connected to a supported dedicated GPU directly. For more information see github.com/JackD83/ALVR/issues/130";
-            }
-
-            return error;
         }
     }
 }

--- a/CrashReport/CrashReport.cs
+++ b/CrashReport/CrashReport.cs
@@ -16,10 +16,25 @@ namespace CrashReport
         {
             InitializeComponent();
 
-            textBox1.Text = Environment.GetCommandLineArgs()[1];
+            textBox1.Text = UserFriendlyError(Environment.GetCommandLineArgs()[1]);
             textBox1.Select(0, 0);
 
             CenterToScreen();
+        }
+
+        private string UserFriendlyError(string error)
+        {
+            if (error == null)
+            {
+                return null;
+            }
+
+            if (error.Contains("Failed to initialize CEncoder. All VideoEncoder are not available. VCE: AMF Error 4. m_amfContext->InitDX11(m_d3dRender->GetDevice()), NVENC: Failed to load nvcuda.dll. Please check if NVIDIA graphic driver is installed."))
+            {
+                return error + " *** This error has been reported to occur when you are running an unsupported GPU, for example an integrated GPU of a CPU, as a main GPU of your system. Please ensure the cable of your monitor is connected to a supported dedicated GPU directly. For more information see github.com/JackD83/ALVR/issues/130";
+            }
+
+            return error;
         }
     }
 }

--- a/alvr_server/CEncoder.cpp
+++ b/alvr_server/CEncoder.cpp
@@ -46,7 +46,11 @@
 			catch (Exception e) {
 				nvencException = e;
 			}
-			throw MakeException(L"All VideoEncoder are not available. VCE: %s, NVENC: %s", vceException.what(), nvencException.what());
+			Exception e = MakeException(L"All VideoEncoder are not available. VCE: %s, NVENC: %s", vceException.what(), nvencException.what());
+			if (0 == strcmp(e.what, L"Failed to initialize CEncoder. All VideoEncoder are not available. VCE: AMF Error 4. m_amfContext->InitDX11(m_d3dRender->GetDevice()), NVENC: Failed to load nvcuda.dll. Please check if NVIDIA graphic driver is installed.")) {
+				 e = MakeException(L"%s *** %s", e.what, L"This error has been reported to occur when you are running an unsupported GPU, for example an integrated GPU of a CPU, as a main GPU of your system. Please ensure the cable of your monitor is connected to a supported dedicated GPU directly. For more information see github.com/JackD83/ALVR/issues/130");
+			}
+			throw e;
 		}
 
 		bool CEncoder::CopyToStaging(ID3D11Texture2D *pTexture[][2], vr::VRTextureBounds_t bounds[][2], int layerCount, bool recentering


### PR DESCRIPTION
As discussed in #130, I suggest a simple solution to improve the user experience by documenting a situation of an unsupported GPU, which is caused by a dependency that doesn't provide any direct information about the issue other than the error message, which doesn't contain any variable parts.

This example can also serve as a framework for error encapsulation in the future whenever other similar issues get reported by other users. To prevent any ambiguity for experts who may prefer the error message, I only appended the description at the end, separating the message using "***" and adding an issue link. The TextBox of the CrashReport has an issue of being too small though, as it doesn't support scrolling, only horizontal resizing. I didn't want to modify the module at my own discretion, so keep this in mind. Here is how it looks to the end users:

![CrashReport](https://user-images.githubusercontent.com/3118390/80736932-191a1280-8b13-11ea-8364-ab42294d5c6e.png)