### PR TITLE
fix colorCorrectionPixelShader's gamma correction and change color space.

### DIFF
--- a/alvr_server/driver_virtual_display.vcxproj
+++ b/alvr_server/driver_virtual_display.vcxproj
@@ -69,6 +69,9 @@
     <PostBuildEvent>
       <Command>xcopy "$(TargetPath)" "$(SolutionDir)driver\bin\win64\" /Y</Command>
     </PostBuildEvent>
+    <FxCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </FxCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -95,6 +98,9 @@
     <PostBuildEvent>
       <Command>xcopy "$(TargetPath)" "$(SolutionDir)driver\bin\win64\" /Y</Command>
     </PostBuildEvent>
+    <FxCompile>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </FxCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\ALVR-common\common-utils.cpp" />
@@ -177,6 +183,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="shader\color.hlsli" />
     <None Include="shader\FoveatedRendering.hlsli" />
   </ItemGroup>
   <ItemGroup>

--- a/alvr_server/shader/ColorCorrectionPixelShader.hlsl
+++ b/alvr_server/shader/ColorCorrectionPixelShader.hlsl
@@ -39,10 +39,12 @@ float4 main(float2 uv : TEXCOORD0) : SV_Target{
 	pixel += GetSharpenNeighborComponent(uv, -DX, +DY);
 	pixel += GetSharpenNeighborComponent(uv, -DX, 0);
 
-	pixel = pow(pixel, 1. / gamma);                                            // gamma
 	pixel += brightness;                                                       // brightness
 	pixel = (pixel - 0.5) * contrast + 0.5f;                                   // contast
 	pixel = lerp(dot(pixel, float3(0.299, 0.587, 0.114)), pixel, saturation);  // saturation
+
+	pixel = clamp(pixel, 0, 1);
+	pixel = pow(pixel, 1. / gamma);                                            // gamma
 
 	return float4(pixel, 1);
 }

--- a/alvr_server/shader/FrameRender.fx
+++ b/alvr_server/shader/FrameRender.fx
@@ -1,3 +1,5 @@
+#include "color.hlsli"
+
 Texture2D txLeft : register(t0);
 Texture2D txRight : register(t1);
 SamplerState samLinear : register(s0);
@@ -26,10 +28,15 @@ PS_INPUT VS(VS_INPUT input)
 }
 float4 PS(PS_INPUT input) : SV_Target
 {
+	float4 output;
 	if (input.View == (uint)0) { // Left View
-		return txLeft.Sample(samLinear, input.Tex);
+		output = txLeft.Sample(samLinear, input.Tex);
+		output.rgb = Rec709ToRec2020(output.rgb);
+		return output;
 	}
 	else { // Right View
-		return txRight.Sample(samLinear, input.Tex);
+		output = txRight.Sample(samLinear, input.Tex);
+		output.rgb = Rec709ToRec2020(output.rgb);
+		return output;
 	}
 };

--- a/alvr_server/shader/color.hlsli
+++ b/alvr_server/shader/color.hlsli
@@ -1,0 +1,90 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+// These values must match the DisplayCurve enum in D3D12HDR.h.
+#define DISPLAY_CURVE_SRGB      0
+#define DISPLAY_CURVE_ST2084    1
+#define DISPLAY_CURVE_LINEAR    2
+
+float3 xyYToRec709(float2 xy, float Y = 1.0)
+{
+    // https://github.com/ampas/aces-dev/blob/v1.0.3/transforms/ctl/README-MATRIX.md
+    static const float3x3 XYZtoRGB =
+    {
+        3.2409699419, -1.5373831776, -0.4986107603,
+        -0.9692436363, 1.8759675015, 0.0415550574,
+        0.0556300797, -0.2039769589, 1.0569715142
+    };
+    float3 XYZ = Y * float3(xy.x / xy.y, 1.0, (1.0 - xy.x - xy.y) / xy.y);
+    float3 RGB = mul(XYZtoRGB, XYZ);
+    float maxChannel = max(RGB.r, max(RGB.g, RGB.b));
+    return RGB / max(maxChannel, 1.0);
+}
+
+float3 xyYToRec2020(float2 xy, float Y = 1.0)
+{
+    // https://github.com/ampas/aces-dev/blob/v1.0.3/transforms/ctl/README-MATRIX.md
+    static const float3x3 XYZtoRGB =
+    {
+        1.7166511880, -0.3556707838, -0.2533662814,
+        -0.6666843518, 1.6164812366, 0.0157685458,
+        0.0176398574, -0.0427706133, 0.9421031212
+    };
+    float3 XYZ = Y * float3(xy.x / xy.y, 1.0, (1.0 - xy.x - xy.y) / xy.y);
+    float3 RGB = mul(XYZtoRGB, XYZ);
+    float maxChannel = max(RGB.r, max(RGB.g, RGB.b));
+    return RGB / max(maxChannel, 1.0);
+}
+
+float3 LinearToSRGB(float3 color)
+{
+    // Approximately pow(color, 1.0 / 2.2)
+    return color < 0.0031308 ? 12.92 * color : 1.055 * pow(abs(color), 1.0 / 2.4) - 0.055;
+}
+
+float3 SRGBToLinear(float3 color)
+{
+    // Approximately pow(color, 2.2)
+    return color < 0.04045 ? color / 12.92 : pow(abs(color + 0.055) / 1.055, 2.4);
+}
+
+float3 Rec709ToRec2020(float3 color)
+{
+    static const float3x3 conversion =
+    {
+        0.627402, 0.329292, 0.043306,
+        0.069095, 0.919544, 0.011360,
+        0.016394, 0.088028, 0.895578
+    };
+    return mul(conversion, color);
+}
+
+float3 Rec2020ToRec709(float3 color)
+{
+    static const float3x3 conversion =
+    {
+        1.660496, -0.587656, -0.072840,
+        -0.124547, 1.132895, -0.008348,
+        -0.018154, -0.100597, 1.118751
+    };
+    return mul(conversion, color);
+}
+
+float3 LinearToST2084(float3 color)
+{
+    float m1 = 2610.0 / 4096.0 / 4;
+    float m2 = 2523.0 / 4096.0 * 128;
+    float c1 = 3424.0 / 4096.0;
+    float c2 = 2413.0 / 4096.0 * 32;
+    float c3 = 2392.0 / 4096.0 * 32;
+    float3 cp = pow(abs(color), m1);
+    return pow((c1 + c2 * cp) / (1 + c3 * cp), m2);
+}


### PR DESCRIPTION
1. fix colorCorrectionPixelShader
2. change color space from Rec.709(Rift S/sRGB) to Rec.2020(Quest)

1.
Inside the colorCorrectionPixelShader, after applying the sharpen filter, gamma correction is performed with the pow function, but the pow function does not support negative values, so there was a problem in the image.
It was solved by inserting the clamp function just before the pow function.

2.
Oculus Quest's color space is Rec.2020.
[Oculus Device Specifications](https://developer.oculus.com/design/oculus-device-specs/)
convert color space from Rec.709(sRGB) to Rec.2020