### PR TITLE
Add information in the readme for notebook users with dedicated GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a fork of [ALVR](https://github.com/polygraphene/ALVR) that works only w
   - Windows 10 May 2020 update is recommended. If you are on an older version, you need to install Chrome or another Chromium based browser.
   - NVIDIA GPU that supports NVENC ([Supported GPUs](https://github.com/polygraphene/ALVR/wiki/Supported-GPU)) (or with an AMD GPU that supports AMF VCE) with the latest driver.
   - Currently only NVIDIA GPUs are supported on Windows 7.
-  - Laptops with dual GPU have to disable the on-board GPU.
+  - Laptops with an onboard (Intel HD, AMD iGPU) and an additional dedicated GPU (NVidia GTX/RTX, AMD HD/R5/R7) should assign the dedicated GPU or "high performance graphics adapter" to the applications ALVR, SteamVR for best performance and compatibility. (NVidia: Nvidia control panel->3d settings->application settings; AMD: similiar way)
 - 802.11ac wireless or ethernet wired connection
   - It is recommended to use 802.11ac for the headset and ethernet for PC
   - You need to connect both the PC and the headset to same router (or use a routed connection as described [here](https://github.com/JackD83/ALVR/wiki/ALVR-client-and-server-on-separate-networks))

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a fork of [ALVR](https://github.com/polygraphene/ALVR) that works only w
   - Windows 10 May 2020 update is recommended. If you are on an older version, you need to install Chrome or another Chromium based browser.
   - NVIDIA GPU that supports NVENC ([Supported GPUs](https://github.com/polygraphene/ALVR/wiki/Supported-GPU)) (or with an AMD GPU that supports AMF VCE) with the latest driver.
   - Currently only NVIDIA GPUs are supported on Windows 7.
-  - Laptops with an onboard (Intel HD, AMD iGPU) and an additional dedicated GPU (NVidia GTX/RTX, AMD HD/R5/R7) should assign the dedicated GPU or "high performance graphics adapter" to the applications ALVR, SteamVR for best performance and compatibility. (NVidia: Nvidia control panel->3d settings->application settings; AMD: similiar way)
+  - Laptops with an onboard (Intel HD, AMD iGPU) and an additional dedicated GPU (NVidia GTX/RTX, AMD HD/R5/R7): you should assign the dedicated GPU or "high performance graphics adapter" to the applications ALVR, SteamVR for best performance and compatibility. (NVidia: Nvidia control panel->3d settings->application settings; AMD: similiar way)
 - 802.11ac wireless or ethernet wired connection
   - It is recommended to use 802.11ac for the headset and ethernet for PC
   - You need to connect both the PC and the headset to same router (or use a routed connection as described [here](https://github.com/JackD83/ALVR/wiki/ALVR-client-and-server-on-separate-networks))


### PR DESCRIPTION
regarding the readme "Laptops with dual GPU have to disable the on-board GPU." in my experience the onboard graphics can't be disabled, because the  graphics ouput of the dedicated GFX needs to be passed through over the onboard GFX. the dedicated GFX needs to be assigned to the 3d application by settings in the related control panel of the GFX