### PR TITLE
Basic session extrapolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,16 +26,18 @@ dependencies = [
 
 [[package]]
 name = "alcro"
-version = "0.1.3"
-source = "git+https://github.com/Srinivasa314/alcro#b8a6346ac8f08a4541d9dfb68b06e52b92b44705"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e62b68ec8a0625b7e474426b8def725f2b04cf6ba700117cbd66ab95c48c9029"
 dependencies = [
  "crossbeam-channel",
- "regex",
+ "libc",
+ "os_str_bytes",
  "serde",
  "serde_json",
  "tempdir",
  "tinyfiledialogs",
- "websocket",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -83,7 +85,7 @@ dependencies = [
  "bincode",
  "chrono",
  "fern",
- "futures 0.3.5",
+ "futures",
  "log 0.4.8",
  "msgbox",
  "serde",
@@ -179,25 +181,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
@@ -283,16 +266,6 @@ name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-
-[[package]]
-name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
 
 [[package]]
 name = "bytes"
@@ -386,7 +359,7 @@ checksum = "f29f7768b2d1be17b96158e3285951d366b40211320fb30826a76cb7a0da6400"
 dependencies = [
  "bitflags",
  "block",
- "core-foundation 0.6.4",
+ "core-foundation",
  "core-graphics",
  "foreign-types",
  "libc",
@@ -405,17 +378,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 dependencies = [
- "core-foundation-sys 0.6.2",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-dependencies = [
- "core-foundation-sys 0.7.0",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -426,19 +389,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
-
-[[package]]
 name = "core-graphics"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
 dependencies = [
  "bitflags",
- "core-foundation 0.6.4",
+ "core-foundation",
  "foreign-types",
  "libc",
 ]
@@ -655,12 +612,6 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "futures"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
@@ -968,7 +919,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -989,7 +940,7 @@ checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
  "base64 0.12.1",
  "bitflags",
- "bytes 0.5.4",
+ "bytes",
  "headers-core",
  "http",
  "mime 0.3.16",
@@ -1030,7 +981,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -1041,7 +992,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "http",
 ]
 
@@ -1053,30 +1004,11 @@ checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
 name = "hyper"
-version = "0.10.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
-dependencies = [
- "base64 0.9.3",
- "httparse",
- "language-tags",
- "log 0.3.9",
- "mime 0.2.6",
- "num_cpus",
- "time",
- "traitobject",
- "typeable",
- "unicase 1.4.2",
- "url 1.7.2",
-]
-
-[[package]]
-name = "hyper"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1092,17 +1024,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "want",
-]
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -1131,7 +1052,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
 ]
 
 [[package]]
@@ -1160,12 +1081,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,15 +1091,6 @@ name = "libc"
 version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
-
-[[package]]
-name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1380,24 +1286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
-dependencies = [
- "lazy_static",
- "libc",
- "log 0.4.8",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "net2"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,37 +1368,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
-name = "openssl"
-version = "0.10.29"
+name = "os_str_bytes"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "lazy_static",
- "libc",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7410fef80af8ac071d4f63755c0ab89ac3df0fd1ea91f1d1f37cf5cec4395990"
-dependencies = [
- "autocfg 1.0.0",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
+checksum = "06de47b848347d8c4c94219ad8ecd35eb90231704b067e67e6ae2e36ee023510"
 
 [[package]]
 name = "pango"
@@ -1538,38 +1399,6 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[package]]
-name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api",
- "parking_lot_core",
- "rustc_version",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-dependencies = [
- "cfg-if",
- "cloudabi",
- "libc",
- "redox_syscall",
- "rustc_version",
- "smallvec 0.6.13",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -1644,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7505eeebd78492e0f6108f7171c4948dbb120ee8119d9d77d0afa5469bef67f"
+checksum = "9df32da11d84f3a7d70205549562966279adb900e080fad3dccd8e64afccf0ad"
 
 [[package]]
 name = "pin-utils"
@@ -1983,15 +1812,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,16 +1833,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = [
- "lazy_static",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,33 +1845,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "security-framework"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
-dependencies = [
- "bitflags",
- "core-foundation 0.7.0",
- "core-foundation-sys 0.7.0",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
-dependencies = [
- "core-foundation-sys 0.7.0",
- "libc",
-]
-
-[[package]]
 name = "semver"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
 dependencies = [
  "semver-parser",
 ]
@@ -2074,18 +1861,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
+checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
+checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2112,7 +1899,7 @@ dependencies = [
  "dtoa",
  "itoa",
  "serde",
- "url 2.1.1",
+ "url",
 ]
 
 [[package]]
@@ -2147,12 +1934,6 @@ dependencies = [
  "fake-simd",
  "opaque-debug",
 ]
-
-[[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2190,15 +1971,6 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
@@ -2217,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e33a62f20d3dc02a1bc9c1d385f92b459bbf35e4dc325eed20c53db5b90c03"
+checksum = "bb37da98a55b1d08529362d9cbb863be17556873df2585904ab9d2bc951291d0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2324,7 +2096,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "fnv",
  "futures-core",
  "iovec",
@@ -2342,38 +2114,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-codec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "tokio-io",
-]
-
-[[package]]
-name = "tokio-executor"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
-dependencies = [
- "crossbeam-utils",
- "futures 0.1.29",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "log 0.4.8",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2385,66 +2125,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-reactor"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
-dependencies = [
- "crossbeam-utils",
- "futures 0.1.29",
- "lazy_static",
- "log 0.4.8",
- "mio",
- "num_cpus",
- "parking_lot",
- "slab",
- "tokio-executor",
- "tokio-io",
- "tokio-sync",
-]
-
-[[package]]
-name = "tokio-sync"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
-dependencies = [
- "fnv",
- "futures 0.1.29",
-]
-
-[[package]]
-name = "tokio-tcp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "iovec",
- "mio",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
-dependencies = [
- "futures 0.1.29",
- "native-tls",
- "tokio-io",
-]
-
-[[package]]
 name = "tokio-tungstenite"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
 dependencies = [
- "futures 0.3.5",
+ "futures",
  "log 0.4.8",
  "pin-project",
  "tokio",
@@ -2457,7 +2143,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes 0.5.4",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log 0.4.8",
@@ -2481,12 +2167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2500,14 +2180,14 @@ checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
 dependencies = [
  "base64 0.11.0",
  "byteorder",
- "bytes 0.5.4",
+ "bytes",
  "http",
  "httparse",
  "input_buffer",
  "log 0.4.8",
  "rand 0.7.3",
  "sha-1",
- "url 2.1.1",
+ "url",
  "utf-8",
 ]
 
@@ -2519,12 +2199,6 @@ checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "typeable"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
@@ -2565,7 +2239,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.4.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -2582,24 +2256,13 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 dependencies = [
- "idna 0.2.0",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2613,12 +2276,6 @@ name = "utf-8"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "version_check"
@@ -2659,11 +2316,11 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e95175b7a927258ecbb816bdada3cc469cb68593e7940b96a60f4af366a9970"
 dependencies = [
- "bytes 0.5.4",
- "futures 0.3.5",
+ "bytes",
+ "futures",
  "headers",
  "http",
- "hyper 0.13.6",
+ "hyper",
  "log 0.4.8",
  "mime 0.3.16",
  "mime_guess 2.0.3",
@@ -2684,47 +2341,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "websocket"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413b37840b9e27b340ce91b319ede10731de8c72f5bc4cb0206ec1ca4ce581d0"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "hyper 0.10.16",
- "native-tls",
- "rand 0.6.5",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
- "tokio-tcp",
- "tokio-tls",
- "unicase 1.4.2",
- "url 1.7.2",
- "websocket-base",
-]
-
-[[package]]
-name = "websocket-base"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3810f0d00c4dccb54c30a4eee815e703232819dec7b007db115791c42aa374"
-dependencies = [
- "base64 0.10.1",
- "bitflags",
- "byteorder",
- "bytes 0.4.12",
- "futures 0.1.29",
- "native-tls",
- "rand 0.6.5",
- "sha1",
- "tokio-codec",
- "tokio-io",
- "tokio-tcp",
- "tokio-tls",
-]
 
 [[package]]
 name = "which"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,9 +1515,9 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
+checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid",
 ]
@@ -1813,9 +1813,9 @@ checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "ryu"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safemem"
@@ -1989,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb37da98a55b1d08529362d9cbb863be17556873df2585904ab9d2bc951291d0"
+checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"
+checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
 dependencies = [
  "gimli",
 ]
@@ -26,8 +26,8 @@ dependencies = [
 
 [[package]]
 name = "alcro"
-version = "0.1.0"
-source = "git+https://github.com/Srinivasa314/alcro#5e04fee0de119bf7d61d045473ef5031d78208a0"
+version = "0.1.3"
+source = "git+https://github.com/Srinivasa314/alcro#b8a6346ac8f08a4541d9dfb68b06e52b92b44705"
 dependencies = [
  "crossbeam-channel",
  "regex",
@@ -312,12 +312,13 @@ dependencies = [
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.8+1.0.8"
+version = "0.1.9+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05305b41c5034ff0e93937ac64133d109b5a2660114ec45e9760bc6816d83038"
+checksum = "ad3b39a260062fca31f7b0b12f207e8f2590a67d32ec7d59c20484b07ea7285e"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -347,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.52"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
+checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
 
 [[package]]
 name = "cfg-if"
@@ -489,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+checksum = "ab6bffe714b6bb07e42f201352c34f51fefd355ace793f9e638ebd52d23f98d2"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -608,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "fnv"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -1016,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
+checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 dependencies = [
  "libc",
 ]
@@ -1071,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
+checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
 dependencies = [
  "bytes 0.5.4",
  "futures-channel",
@@ -1085,8 +1086,8 @@ dependencies = [
  "httparse",
  "itoa",
  "log 0.4.8",
- "net2",
  "pin-project",
+ "socket2",
  "time",
  "tokio",
  "tower-service",
@@ -1172,9 +1173,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "lock_api"
@@ -1312,7 +1313,7 @@ checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
 dependencies = [
  "log 0.4.8",
  "mio",
- "miow 0.3.3",
+ "miow 0.3.4",
  "winapi 0.3.8",
 ]
 
@@ -1341,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
+checksum = "22dfdd1d51b2639a5abd17ed07005c3af05fb7a2a3b1a1d0d7af1000a520c1c7"
 dependencies = [
  "socket2",
  "winapi 0.3.8",
@@ -1352,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "msgbox"
 version = "0.5.0"
-source = "git+https://github.com/zarik5/msgbox-rs#6d7ab96509fe7004e60d7ab46de3e2721232de26"
+source = "git+https://github.com/bekker/msgbox-rs#66384fb2855346bb33be01581718f53a569cc75f"
 dependencies = [
  "cocoa",
  "gtk",
@@ -1623,18 +1624,18 @@ checksum = "3ad1f1b834a05d42dae330066e9699a173b28185b3bdc3dbf14ca239585de8cc"
 
 [[package]]
 name = "pin-project"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d480cb4e89522ccda96d0eed9af94180b7a5f93fb28f66e1fd7d68431663d1"
+checksum = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82996f11efccb19b685b14b5df818de31c1edcee3daa256ab5775dd98e72feb"
+checksum = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1661,21 +1662,21 @@ checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "podio"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
+checksum = "b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
@@ -1685,9 +1686,9 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
+checksum = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
 dependencies = [
  "unicode-xid",
 ]
@@ -1700,9 +1701,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42934bc9c8ab0d3b273a16d8551c8f0fcff46be73276ca083ec2414c15c4ba5e"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
  "proc-macro2",
 ]
@@ -1928,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.7"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1940,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
@@ -2216,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.21"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4696caa4048ac7ce2bcd2e484b3cef88c1004e41b8e945a277e2c25dc0b72060"
+checksum = "e7e33a62f20d3dc02a1bc9c1d385f92b459bbf35e4dc325eed20c53db5b90c03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2239,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.14.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d070254b7172eee9eb3990bea8f72aeabfe1226c40bf71a52e4fe75777812e9a"
+checksum = "4cf74492539712b190e4b3234cf6a4a026812e880fe45e8001807cc0044a7f21"
 dependencies = [
  "cfg-if",
  "doc-comment",
@@ -2546,7 +2547,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -2627,9 +2628,9 @@ checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "walkdir"
@@ -2654,15 +2655,15 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cd1e2b3eb3539284d88b76a9afcf5e20f2ef2fab74db5b21a1c30d7d945e82"
+checksum = "0e95175b7a927258ecbb816bdada3cc469cb68593e7940b96a60f4af366a9970"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.5",
  "headers",
  "http",
- "hyper 0.13.5",
+ "hyper 0.13.6",
  "log 0.4.8",
  "mime 0.3.16",
  "mime_guess 2.0.3",

--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@
 
 # ALVR - Air Light VR
 
-Stream VR games from your PC to your Oculus Quest via Wi-FI.
-
+Stream VR games from your PC to your Oculus Quest via Wi-FI.  
 ALVR uses technologies like Asynchronous Timewarp and Fixed Foveated Rendering for a smoother experience.
 
-All games that work with a Oculus Rift (s) should work with ALVR
-
+All games that work with an Oculus Rift (s) should work with ALVR.  
 This is a fork of [ALVR](https://github.com/polygraphene/ALVR) that works only with Oculus Quest.
 
 ## Requirements
@@ -48,7 +46,7 @@ Install the client on your headset through [SideQuest](https://sidequestvr.com/)
 
 - Floorlevel: Use the SteamVR room setup to calibrate the room as standing only. Put your Quest on the ground while calibrating. Make sure that the stream is still working by covering the light sensor of the quest. Enter a height of 0 into the room setup.
 Now you can press and hold the oculus key on the right controller to recenter SteamVR and fix the floor height at any time.
-- To reset ALVR, delete the files `session.json` and `settings.json` from the installation folder.
+- To reset ALVR, delete the file `session.json` from the installation folder.
 - Please check the [Troubleshooting](https://github.com/polygraphene/ALVR/wiki/Troubleshooting) page on the original repository.
 - You can find some setup advice [here](https://github.com/JackD83/ALVR/wiki/Setup-advice).
 
@@ -64,7 +62,7 @@ If you have a version prior to 11.0 you need to launch `remove_firewall_rules.ba
 - Install [Visual Studio Community 2019](https://visualstudio.microsoft.com/downloads) with C++ build tools
 - Alternatively, if you already have a Visual Studio 2019 installation, you can add the environment variable `MSBUILD_DIR` pointing to the folder containing `MSBuild.exe`
 - Install [CUDA 10.2](https://developer.nvidia.com/cuda-downloads?target_os=Windows&target_arch=x86_64&target_version=10&target_type=exenetwork)
-- Install Android Studio >=3.4, API Level 29. Requires LLDB and NDK
+- Install Android Studio >=3.4, API Level 29. Requires LLDB and NDK. The environment variable `JAVA_HOME` must be set.
 - Install [rustup](https://rustup.rs/)
 - Download this repository and on the project root execute:
 

--- a/alvr/common/Cargo.toml
+++ b/alvr/common/Cargo.toml
@@ -6,7 +6,7 @@ license = 'MIT'
 edition = '2018'
 
 [dependencies]
-semver = '^0.9.0'
+semver = '^0.10.0'
 serde = { version = '^1.0', features = ['derive'] }
 serde_json = '^1.0'
 log = '^0.4.8'

--- a/alvr/common/Cargo.toml
+++ b/alvr/common/Cargo.toml
@@ -13,6 +13,7 @@ log = '^0.4.8'
 backtrace = '^0.3.46'
 settings-schema = { git = 'https://github.com/zarik5/settings-schema-rs', features = ['rename_camel_case'] }
 sysinfo = '^0.14.1'
+alvr_xtask = { path = '../xtask' }
 
 [build-dependencies]
 alvr_xtask = { path = '../xtask' }

--- a/alvr/common/src/data/mod.rs
+++ b/alvr/common/src/data/mod.rs
@@ -57,7 +57,6 @@ pub struct ClientConnectionDesc {
 #[serde(rename_all = "camelCase")]
 pub struct SessionDesc {
     pub setup_wizard: bool,
-    pub version: String,
     pub revert_confirm_dialog: bool,
     pub restart_confirm_dialog: bool,
     pub last_clients: Vec<ClientConnectionDesc>,
@@ -67,7 +66,6 @@ pub struct SessionDesc {
 impl Default for SessionDesc {
     fn default() -> Self {
         Self {
-            version: ALVR_SERVER_VERSION.into(),
             setup_wizard: true,
             revert_confirm_dialog: true,
             restart_confirm_dialog: true,

--- a/alvr/common/src/data/mod.rs
+++ b/alvr/common/src/data/mod.rs
@@ -11,6 +11,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use logging::LogId;
 pub use settings::*;
 pub use version::*;
 
@@ -18,12 +19,15 @@ type SettingsCache = SettingsDefault;
 
 pub const SESSION_FNAME: &str = "session.json";
 
-pub fn load_json<T: de::DeserializeOwned>(path: &Path) -> StrResult<T> {
+pub fn load_session(path: &Path) -> StrResult<SessionDesc> {
     trace_err!(json::from_str(&trace_err!(fs::read_to_string(path))?))
 }
 
-pub fn save_json<T: Serialize>(obj: &T, path: &Path) -> StrResult {
-    trace_err!(fs::write(path, trace_err!(json::to_string_pretty(obj))?))
+pub fn save_session(session_desc: &SessionDesc, path: &Path) -> StrResult {
+    trace_err!(fs::write(
+        path,
+        trace_err!(json::to_string_pretty(session_desc))?
+    ))
 }
 
 #[repr(C)]
@@ -53,7 +57,9 @@ pub struct ClientConnectionDesc {
 #[serde(rename_all = "camelCase")]
 pub struct SessionDesc {
     pub setup_wizard: bool,
+    pub version: String,
     pub revert_confirm_dialog: bool,
+    pub restart_confirm_dialog: bool,
     pub last_clients: Vec<ClientConnectionDesc>,
     pub settings_cache: SettingsCache,
 }
@@ -61,24 +67,300 @@ pub struct SessionDesc {
 impl Default for SessionDesc {
     fn default() -> Self {
         Self {
+            version: ALVR_SERVER_VERSION.into(),
             setup_wizard: true,
             revert_confirm_dialog: true,
+            restart_confirm_dialog: true,
             last_clients: vec![],
             settings_cache: settings_cache_default(),
         }
     }
 }
 
-// This function requires that settings enums with data have tag = "type" and content="content", and
-// enums without data do not have tag and content set.
-// unwrap() calls never panic because SettingsCache structure is generated from Settings
-pub fn session_to_settings(session: &SessionDesc) -> Settings {
-    let cache_value = json::to_value(&session.settings_cache).unwrap();
-    let schema = settings_schema(settings_cache_default());
-    json::from_value(cache_to_settings_impl(&cache_value, &schema)).unwrap()
+impl SessionDesc {
+    // If json_value is not a valid representation of SessionDesc (because of version upgrade), use
+    // some fuzzy logic to extrapolate as much information as possible.
+    // Since SessionDesc cannot have a schema (because SettingsCache would need to also have a
+    // schema, but it is generated out of our control), I only do basic name checking on fields and
+    // deserialization will fail if the type of values does not match. Because of this,
+    // `settings_cache` must be handled separately to do a better job of retrieving data using the
+    // settings schema.
+    pub fn merge_from_json(&mut self, json_value: json::Value) -> StrResult {
+        const SETTINGS_CACHE_STR: &str = "settings_cache";
+
+        if let Ok(session_desc) = json::from_value(json_value.clone()) {
+            *self = session_desc;
+            return Ok(());
+        }
+
+        let old_session_json = json::to_value(SessionDesc::default()).unwrap();
+        let old_session_fields = old_session_json.as_object().unwrap();
+        let new_session_fields = json_value.as_object().unwrap();
+
+        let settings_cache_json = new_session_fields
+            .get(SETTINGS_CACHE_STR)
+            .map(|new_cache_json| {
+                extrapolate_settings_cache(
+                    &old_session_json[SETTINGS_CACHE_STR],
+                    new_cache_json,
+                    &settings_schema(settings_cache_default()),
+                )
+            })
+            .unwrap_or_else(|| json_value.clone());
+
+        let new_fields = old_session_fields
+            .iter()
+            .map(|(name, json_value)| {
+                let new_json_value = if name == SETTINGS_CACHE_STR {
+                    json::to_value(settings_cache_default()).unwrap()
+                } else {
+                    new_session_fields.get(name).unwrap_or(json_value).clone()
+                };
+                (name.clone(), new_json_value)
+            })
+            .collect();
+        // Failure to extrapolate other session_desc fields is not notified.
+        let mut session_desc_mut =
+            json::from_value::<SessionDesc>(json::Value::Object(new_fields)).unwrap_or_default();
+
+        match json::from_value::<SettingsCache>(settings_cache_json) {
+            Ok(settings_cache) => {
+                session_desc_mut.settings_cache = settings_cache;
+                *self = session_desc_mut;
+            }
+            Err(e) => {
+                *self = session_desc_mut;
+                return trace_str!(
+                    id: LogId::SettingsCacheExtrapolationFailed,
+                    "Error while deserializing extrapolated settings cache: {}",
+                    e
+                );
+            }
+        }
+
+        Ok(())
+    }
 }
 
-fn cache_to_settings_impl(cache_value: &json::Value, schema: &SchemaNode) -> json::Value {
+// Current data extrapolation strategy: match both field name and value type exactly.
+// Integer bounds are not validated, if they do not match the schema, deserialization will fail and
+// all data is lost.
+// Future strategies: check if value respects schema constraints, fuzzy field name matching, accept
+// integer to float and float to integer, tree traversal.
+fn extrapolate_settings_cache(
+    old_cache: &json::Value,
+    new_cache: &json::Value,
+    schema: &SchemaNode,
+) -> json::Value {
+    match schema {
+        SchemaNode::Section { entries } => json::Value::Object(
+            entries
+                .iter()
+                .filter_map(|(field_name, maybe_data)| {
+                    maybe_data.as_ref().map(|data_schema| {
+                        let value_json = if let Some(new_value_json) = new_cache.get(field_name) {
+                            extrapolate_settings_cache(
+                                &old_cache[field_name],
+                                new_value_json,
+                                &data_schema.content,
+                            )
+                        } else {
+                            old_cache[field_name].clone()
+                        };
+                        (field_name.clone(), value_json)
+                    })
+                })
+                .collect(),
+        ),
+
+        SchemaNode::Choice { variants, .. } => {
+            let variant_json = new_cache
+                .get("variant")
+                .cloned()
+                .filter(|new_variant_json| {
+                    new_variant_json
+                        .as_str()
+                        .map(|variant_str| {
+                            variants
+                                .iter()
+                                .any(|(variant_name, _)| variant_str == variant_name)
+                        })
+                        .is_some()
+                })
+                .unwrap_or_else(|| old_cache["variant"].clone());
+
+            let mut fields: json::Map<_, _> = variants
+                .iter()
+                .filter_map(|(variant_name, maybe_data)| {
+                    maybe_data.as_ref().map(|data_schema| {
+                        let value_json = if let Some(new_value_json) = new_cache.get(variant_name) {
+                            extrapolate_settings_cache(
+                                &old_cache[variant_name],
+                                new_value_json,
+                                &data_schema.content,
+                            )
+                        } else {
+                            old_cache[variant_name].clone()
+                        };
+                        (variant_name.clone(), value_json)
+                    })
+                })
+                .collect();
+            fields.insert("variant".into(), variant_json);
+
+            json::Value::Object(fields)
+        }
+
+        SchemaNode::Optional { content, .. } => {
+            let set_json = new_cache
+                .get("set")
+                .cloned()
+                .filter(|new_set_json| new_set_json.is_boolean())
+                .unwrap_or_else(|| old_cache["set"].clone());
+
+            let content_json = new_cache
+                .get("content")
+                .map(|new_content_json| {
+                    extrapolate_settings_cache(&old_cache["content"], new_content_json, content)
+                })
+                .unwrap_or_else(|| old_cache["content"].clone());
+
+            json::json!({
+                "set": set_json,
+                "content": content_json
+            })
+        }
+
+        SchemaNode::Switch { content, .. } => {
+            let enabled_json = new_cache
+                .get("enabled")
+                .cloned()
+                .filter(|new_enabled_json| new_enabled_json.is_boolean())
+                .unwrap_or_else(|| old_cache["enabled"].clone());
+
+            let content_json = new_cache
+                .get("content")
+                .map(|new_content_json| {
+                    extrapolate_settings_cache(&old_cache["content"], new_content_json, content)
+                })
+                .unwrap_or_else(|| old_cache["content"].clone());
+
+            json::json!({
+                "enabled": enabled_json,
+                "content": content_json
+            })
+        }
+
+        SchemaNode::Boolean { .. } => {
+            if new_cache.is_boolean() {
+                new_cache.clone()
+            } else {
+                old_cache.clone()
+            }
+        }
+
+        SchemaNode::Integer { .. } => {
+            if new_cache.is_i64() {
+                new_cache.clone()
+            } else {
+                old_cache.clone()
+            }
+        }
+
+        SchemaNode::Float { .. } => {
+            if new_cache.is_f64() {
+                new_cache.clone()
+            } else {
+                old_cache.clone()
+            }
+        }
+
+        SchemaNode::Text { .. } => {
+            if new_cache.is_string() {
+                new_cache.clone()
+            } else {
+                old_cache.clone()
+            }
+        }
+
+        SchemaNode::Array(array_schema) => {
+            let array_vec = (0..array_schema.len())
+                .map(|idx| {
+                    new_cache
+                        .get(idx)
+                        .cloned()
+                        .unwrap_or_else(|| old_cache[idx].clone())
+                })
+                .collect();
+            json::Value::Array(array_vec)
+        }
+
+        SchemaNode::Vector {
+            default_element, ..
+        } => {
+            let element_json = new_cache
+                .get("element")
+                .map(|new_element_json| {
+                    extrapolate_settings_cache(
+                        &old_cache["content"],
+                        new_element_json,
+                        default_element,
+                    )
+                })
+                .unwrap_or_else(|| old_cache["content"].clone());
+
+            // todo: default field cannot be properly validated until I implement plain settings
+            // validation (not to be confused with session/settings_cache validation). Any
+            // problem inside this new_cache default will result in the loss all data in session.
+            let default = new_cache
+                .get("default")
+                .cloned()
+                .unwrap_or_else(|| old_cache["default"].clone());
+
+            json::json!({
+                "element": element_json,
+                "default": default
+            })
+        }
+
+        SchemaNode::Dictionary { default_value, .. } => {
+            let key_json = new_cache
+                .get("key")
+                .cloned()
+                .filter(|new_key| new_key.is_string())
+                .unwrap_or_else(|| old_cache["key"].clone());
+
+            let value_json = new_cache
+                .get("value")
+                .map(|new_value_json| {
+                    extrapolate_settings_cache(&old_cache["value"], new_value_json, default_value)
+                })
+                .unwrap_or_else(|| old_cache["content"].clone());
+
+            // todo: validate default using settings validation
+            let default = new_cache
+                .get("default")
+                .cloned()
+                .unwrap_or_else(|| old_cache["default"].clone());
+
+            json::json!({
+                "key": key_json,
+                "value": value_json,
+                "default": default
+            })
+        }
+    }
+}
+
+// This function requires that settings enums with data have tag = "type" and content = "content", and
+// enums without data do not have tag and content set.
+pub fn session_to_settings(session: &SessionDesc) -> Settings {
+    let cache_json = json::to_value(&session.settings_cache).unwrap();
+    let schema = settings_schema(settings_cache_default());
+    json::from_value(json_cache_to_settings(&cache_json, &schema)).unwrap()
+}
+
+fn json_cache_to_settings(cache: &json::Value, schema: &SchemaNode) -> json::Value {
     match schema {
         SchemaNode::Section { entries } => json::Value::Object(
             entries
@@ -87,14 +369,15 @@ fn cache_to_settings_impl(cache_value: &json::Value, schema: &SchemaNode) -> jso
                     maybe_data.as_ref().map(|data_schema| {
                         (
                             field_name.clone(),
-                            cache_to_settings_impl(&cache_value[field_name], &data_schema.content),
+                            json_cache_to_settings(&cache[field_name], &data_schema.content),
                         )
                     })
                 })
                 .collect(),
         ),
+
         SchemaNode::Choice { variants, .. } => {
-            let variant = cache_value["variant"].clone();
+            let variant = cache["variant"].clone();
             let only_tag = variants
                 .iter()
                 .all(|(_, maybe_data)| matches!(maybe_data, None));
@@ -108,7 +391,7 @@ fn cache_to_settings_impl(cache_value: &json::Value, schema: &SchemaNode) -> jso
                     .map(|(_, maybe_data)| maybe_data.as_ref())
                     .unwrap()
                     .map(|data_schema| {
-                        cache_to_settings_impl(&cache_value[variant], &data_schema.content)
+                        json_cache_to_settings(&cache[variant], &data_schema.content)
                     });
                 json::json!({
                     "type": variant,
@@ -116,47 +399,50 @@ fn cache_to_settings_impl(cache_value: &json::Value, schema: &SchemaNode) -> jso
                 })
             }
         }
+
         SchemaNode::Optional { content, .. } => {
-            if cache_value["set"].as_bool().unwrap() {
-                cache_to_settings_impl(&cache_value["content"], content)
+            if cache["set"].as_bool().unwrap() {
+                json_cache_to_settings(&cache["content"], content)
             } else {
                 json::Value::Null
             }
         }
+
         SchemaNode::Switch { content, .. } => {
             let state;
             let maybe_content;
-            if cache_value["enabled"].as_bool().unwrap() {
+            if cache["enabled"].as_bool().unwrap() {
                 state = "enabled";
-                maybe_content = Some(cache_to_settings_impl(&cache_value["content"], content))
+                maybe_content = Some(json_cache_to_settings(&cache["content"], content))
             } else {
                 state = "disabled";
                 maybe_content = None;
             }
+
             json::json!({
                 "type": state,
                 "content": maybe_content
             })
         }
+
         SchemaNode::Boolean { .. }
         | SchemaNode::Integer { .. }
         | SchemaNode::Float { .. }
-        | SchemaNode::Text { .. } => cache_value.clone(),
+        | SchemaNode::Text { .. } => cache.clone(),
 
         SchemaNode::Array(array_schema) => json::Value::Array(
             array_schema
                 .iter()
                 .enumerate()
                 .map(|(idx, element_schema)| {
-                    cache_to_settings_impl(&cache_value[idx], element_schema)
+                    json_cache_to_settings(&cache[idx], element_schema)
                 })
                 .collect(),
         ),
-        SchemaNode::Vector { .. } | SchemaNode::Dictionary { .. } => cache_value["default"].clone(),
+
+        SchemaNode::Vector { .. } | SchemaNode::Dictionary { .. } => cache["default"].clone(),
     }
 }
-
-// todo: settings_to_cache() -> useful for manual editing of settings
 
 // SessionDesc wrapper that saves settings.json and session.json on destruction.
 pub struct SessionLock<'a> {
@@ -179,12 +465,7 @@ impl DerefMut for SessionLock<'_> {
 
 impl Drop for SessionLock<'_> {
     fn drop(&mut self) {
-        save_json(self.session_desc, &self.dir.join(SESSION_FNAME)).ok();
-        save_json(
-            &session_to_settings(self.session_desc),
-            &self.dir.join(SETTINGS_FNAME),
-        )
-        .ok();
+        save_session(self.session_desc, &self.dir.join(SESSION_FNAME)).ok();
     }
 }
 
@@ -195,7 +476,25 @@ pub struct SessionManager {
 
 impl SessionManager {
     pub fn new(dir: &Path) -> Self {
-        let session_desc = load_json(&dir.join(SESSION_FNAME)).unwrap_or_default();
+        let session_desc = match fs::read_to_string(dir.join(SESSION_FNAME)) {
+            Ok(session_string) => {
+                let json_value = json::from_str::<json::Value>(&session_string).unwrap();
+                match json::from_value(json_value.clone()) {
+                    Ok(session_desc) => session_desc,
+                    Err(_) => {
+                        fs::write(dir.join("session_old.json"), &session_string).ok();
+                        let mut session_desc = SessionDesc::default();
+                        session_desc.merge_from_json(json_value).unwrap();
+                        warn!(
+                            "Session extrapolated. Old session.json is stored as session_old.json"
+                        );
+                        session_desc
+                    }
+                }
+            }
+            Err(_) => SessionDesc::default(),
+        };
+
         Self {
             session_desc,
             dir: dir.to_owned(),
@@ -217,5 +516,13 @@ mod tests {
     #[test]
     fn test_session_to_settings() {
         let _settings = session_to_settings(&SessionDesc::default());
+    }
+
+    // todo: add more tests
+    #[test]
+    fn test_session_extrapolation_trivial() {
+        SessionDesc::default()
+            .merge_from_json(json::to_value(SessionDesc::default()).unwrap())
+            .unwrap();
     }
 }

--- a/alvr/common/src/data/settings.rs
+++ b/alvr/common/src/data/settings.rs
@@ -2,8 +2,6 @@ use serde::{Deserialize, Serialize};
 use settings_schema::*;
 use std::os::raw::c_char;
 
-pub const SETTINGS_FNAME: &str = "settings.json";
-
 #[macro_export]
 macro_rules! extern_getters {
     (@ $struct_name:ident, $field_name:ident, String) => {

--- a/alvr/common/src/logging.rs
+++ b/alvr/common/src/logging.rs
@@ -2,9 +2,12 @@ use serde::{Deserialize, Serialize};
 
 pub type StrResult<T = ()> = Result<T, String>;
 
-pub const DRIVER_LOG_FNAME: &str = "driver_log.txt";
 pub const SESSION_LOG_FNAME: &str = "session_log.txt";
 pub const CRASH_LOG_FNAME: &str = "crash_log.txt";
+
+pub fn driver_log_path() -> std::path::PathBuf {
+    std::env::temp_dir().join("alvr_driver_log.txt")
+}
 
 fn default_show_error_fn(_: &str) {}
 
@@ -36,12 +39,13 @@ pub fn show_err<T, E: std::fmt::Display>(res: Result<T, E>) -> Result<T, ()> {
     })
 }
 
-// Log id is serialized as #{ "id": "...", "data": [...|null] }#
+// Log id is serialized as #{ "id": "..." [, "data": ...] }#
 // Pound signs are used to identify start and finish of json
 #[repr(u8)]
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "id", content = "data")]
 pub enum LogId {
+    SettingsCacheExtrapolationFailed,
     ClientFoundOk,
     ClientFoundInvalid,
     ClientFoundWrongIp,

--- a/alvr/common/src/process.rs
+++ b/alvr/common/src/process.rs
@@ -1,3 +1,4 @@
+use alvr_xtask::*;
 use std::{path::Path, process::*};
 use sysinfo::*;
 
@@ -6,15 +7,6 @@ use std::os::windows::process::CommandExt;
 
 #[cfg(windows)]
 pub const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-
-#[cfg(target_os = "linux")]
-fn exec_fname(name: &str) -> String {
-    name.to_owned()
-}
-#[cfg(windows)]
-fn exec_fname(name: &str) -> String {
-    format!("{}.exe", name)
-}
 
 // Launch web server. If another instance exists, the one just spawned will close itself.
 pub fn maybe_launch_web_server(root_server_dir: &Path) {
@@ -65,4 +57,10 @@ pub fn maybe_kill_web_server() {
             kill_process(process.pid());
         }
     }
+}
+
+pub fn launch_steamvr() {
+    Command::new(steamvr_bin_dir().join(exec_fname("vrmonitor")))
+        .output()
+        .ok();
 }

--- a/alvr/common/src/process.rs
+++ b/alvr/common/src/process.rs
@@ -61,6 +61,6 @@ pub fn maybe_kill_web_server() {
 
 pub fn launch_steamvr() {
     Command::new(steamvr_bin_dir().join(exec_fname("vrmonitor")))
-        .output()
+        .spawn()
         .ok();
 }

--- a/alvr/server_bootstrap/Cargo.toml
+++ b/alvr/server_bootstrap/Cargo.toml
@@ -6,7 +6,7 @@ license = 'MIT'
 edition = '2018'
 
 [dependencies]
-alcro = { git = 'https://github.com/Srinivasa314/alcro' }
+alcro = '^0.1.4'
 alvr_common = { path = '../common' }
 single-instance = '^0.1.2'
 

--- a/alvr/server_driver_ext/src/logging_backend.rs
+++ b/alvr/server_driver_ext/src/logging_backend.rs
@@ -7,7 +7,7 @@ pub fn init_logging() {
     static INIT_LOGGING_ENTRY_POINT: Once = Once::new();
 
     INIT_LOGGING_ENTRY_POINT.call_once(|| {
-        std::fs::remove_file(DRIVER_LOG_FNAME).ok();
+        std::fs::remove_file(driver_log_path()).ok();
 
         if cfg!(debug_assertions) {
             Dispatch::new()
@@ -29,7 +29,7 @@ pub fn init_logging() {
                 })
                 .level(LevelFilter::Info)
         }
-        .chain(log_file(DRIVER_LOG_FNAME).unwrap())
+        .chain(log_file(driver_log_path()).unwrap())
         .apply()
         .unwrap();
     });

--- a/alvr/web_server/src/logging_backend.rs
+++ b/alvr/web_server/src/logging_backend.rs
@@ -1,12 +1,21 @@
 use alvr_common::logging::*;
 use fern::{log_file, Dispatch};
 use log::LevelFilter;
+use std::{
+    fs,
+    sync::{Arc, Mutex},
+};
 use tokio::sync::mpsc::UnboundedSender;
-use std::sync::{Mutex, Arc};
 
 // Define logging modes, create crash log and (re)create session log
 pub fn init_logging(log_senders: Arc<Mutex<Vec<UnboundedSender<String>>>>) {
-    std::fs::remove_file(SESSION_LOG_FNAME).ok();
+    fs::remove_file(SESSION_LOG_FNAME).ok();
+
+    // create driver log file or else the tail command will not work
+    fs::OpenOptions::new()
+        .create(true)
+        .open(driver_log_path())
+        .ok();
 
     if cfg!(debug_assertions) {
         Dispatch::new()

--- a/alvr/web_server/src/main.rs
+++ b/alvr/web_server/src/main.rs
@@ -170,6 +170,11 @@ async fn run(log_senders: Arc<Mutex<Vec<UnboundedSender<String>>>>) -> StrResult
             reply::json(&maybe_err.unwrap_or(0))
         });
 
+    let launch_steamvr_request = warp::path("launch_steamvr").map(|| {
+        process::launch_steamvr();
+        warp::reply()
+    });
+
     warp::serve(
         index_request
             .or(settings_schema_request)
@@ -177,6 +182,7 @@ async fn run(log_senders: Arc<Mutex<Vec<UnboundedSender<String>>>>) -> StrResult
             .or(log_subscription)
             .or(driver_registration_requests)
             .or(firewall_rules_requests)
+            .or(launch_steamvr_request)
             .or(files_requests)
             .with(reply::with::header(
                 "Cache-Control",

--- a/alvr/web_server/src/main.rs
+++ b/alvr/web_server/src/main.rs
@@ -6,7 +6,7 @@ use alvr_common::{data::*, logging::*, *};
 use futures::SinkExt;
 use logging_backend::*;
 use std::{
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{Arc, Mutex},
     time::SystemTime,
 };
@@ -17,6 +17,7 @@ use tokio::{
 };
 use warp::{
     body, fs as wfs,
+    http::StatusCode,
     reply,
     ws::{Message, WebSocket, Ws},
     Filter,
@@ -25,7 +26,11 @@ use warp::{
 const WEB_GUI_DIR_STR: &str = "web_gui";
 
 fn alvr_server_dir() -> PathBuf {
-    std::env::current_exe().unwrap().parent().unwrap().to_owned()
+    std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_owned()
 }
 
 fn try_log_redirect(line: &str, level: log::Level) -> bool {
@@ -90,12 +95,12 @@ async fn client_discovery(session_manager: Arc<Mutex<SessionManager>>) {
 }
 
 async fn run(log_senders: Arc<Mutex<Vec<UnboundedSender<String>>>>) -> StrResult {
-    let session_manager = Arc::new(Mutex::new(SessionManager::new(&Path::new("./"))));
+    let session_manager = Arc::new(Mutex::new(SessionManager::new(&alvr_server_dir())));
 
     tokio::spawn(client_discovery(session_manager.clone()));
 
     let driver_log_redirect = tokio::spawn(
-        tail_stream(DRIVER_LOG_FNAME)?
+        tail_stream(&driver_log_path())?
             .map(|maybe_line: std::io::Result<String>| {
                 if let Ok(line) = maybe_line {
                     if !(try_log_redirect(&line, log::Level::Error)
@@ -118,15 +123,25 @@ async fn run(log_senders: Arc<Mutex<Vec<UnboundedSender<String>>>>) -> StrResult
     let settings_schema_request = warp::path("settings-schema").map(|| env!("SETTINGS_SCHEMA"));
 
     let session_requests = warp::path("session").and(
-        body::json()
+        warp::get()
             .map({
                 let session_manager = session_manager.clone();
-                move |data| {
-                    *session_manager.lock().unwrap().get_mut() = data;
-                    warp::reply()
-                }
+                move || reply::json(&*session_manager.lock().unwrap().get_mut())
             })
-            .or(warp::any().map(move || reply::json(&*session_manager.lock().unwrap().get_mut()))),
+            .or(warp::post().and(body::json().map(move |value| {
+                let res = session_manager
+                    .lock()
+                    .unwrap()
+                    .get_mut()
+                    .merge_from_json(value);
+                if let Err(e) = res {
+                    warn!("{}", e);
+                    // HTTP Code: WARNING
+                    reply::with_status(reply(), StatusCode::from_u16(199).unwrap())
+                } else {
+                    reply::with_status(reply(), StatusCode::OK)
+                }
+            }))),
     );
 
     let log_subscription = warp::path("log").and(warp::ws()).map(move |ws: Ws| {
@@ -137,7 +152,11 @@ async fn run(log_senders: Arc<Mutex<Vec<UnboundedSender<String>>>>) -> StrResult
 
     let driver_registration_requests = warp::path!("driver" / String).map(|action_str: String| {
         let register = action_str == "register";
-        show_err(alvr_xtask::driver_registration(&alvr_server_dir(), register)).ok();
+        show_err(alvr_xtask::driver_registration(
+            &alvr_server_dir(),
+            register,
+        ))
+        .ok();
         warp::reply()
     });
 

--- a/alvr/web_server/src/tail.rs
+++ b/alvr/web_server/src/tail.rs
@@ -1,5 +1,5 @@
 use alvr_common::*;
-use std::process::Stdio;
+use std::{path::Path, process::Stdio};
 use tokio::{io::AsyncBufReadExt, io::BufReader, process::Command, stream::Stream};
 
 #[cfg(not(windows))]
@@ -9,15 +9,15 @@ fn tail_command(fname: &str) -> Command {
     command
 }
 #[cfg(windows)]
-fn tail_command(fname: &str) -> Command {
+fn tail_command(file_path: &Path) -> Command {
     let mut command = Command::new("PowerShell.exe");
     command
-        .args(&["Get-Content", fname, "-Wait"])
+        .args(&["Get-Content", &file_path.to_string_lossy(), "-Wait"])
         .creation_flags(process::CREATE_NO_WINDOW);
     command
 }
 
-pub fn tail_stream(fname: &str) -> StrResult<impl Stream<Item = std::io::Result<String>>> {
-    let process = trace_err!(tail_command(fname).stdout(Stdio::piped()).spawn())?;
+pub fn tail_stream(file_path: &Path) -> StrResult<impl Stream<Item = std::io::Result<String>>> {
+    let process = trace_err!(tail_command(file_path).stdout(Stdio::piped()).spawn())?;
     Ok(BufReader::new(trace_none!(process.stdout)?).lines())
 }

--- a/alvr/xtask/src/lib.rs
+++ b/alvr/xtask/src/lib.rs
@@ -176,10 +176,21 @@ pub fn build_server(is_release: bool) -> BResult {
     fs::create_dir_all(&lib_build_dir)?;
     fs::create_dir_all(&driver_dst_dir)?;
 
+    run("cargo update")?;
+
     run(&format!(
-        "cargo build -p alvr_server_driver_ext {}",
+        "cargo build -p alvr_server_driver_ext -p alvr_web_server -p alvr_server_bootstrap {}",
         build_flag
     ))?;
+    fs::copy(
+        artifacts_dir.join(exec_fname("alvr_web_server")),
+        server_build_dir().join(exec_fname("alvr_web_server")),
+    )?;
+    fs::copy(
+        artifacts_dir.join(exec_fname("alvr_server_bootstrap")),
+        server_build_dir().join(exec_fname("ALVR")),
+    )?;
+
     println!("Please wait for cbindgen...");
     run(&format!(
         "rustup run {} cbindgen --config alvr/server_driver_ext/cbindgen.toml \
@@ -208,20 +219,6 @@ pub fn build_server(is_release: bool) -> BResult {
             driver_dst_dir.join(DRIVER_FNAME),
         )?;
     }
-
-    run(&format!("cargo build -p alvr_web_server {}", build_flag))?;
-    fs::copy(
-        artifacts_dir.join(exec_fname("alvr_web_server")),
-        server_build_dir().join(exec_fname("alvr_web_server")),
-    )?;
-    run(&format!(
-        "cargo build -p alvr_server_bootstrap {}",
-        build_flag
-    ))?;
-    fs::copy(
-        artifacts_dir.join(exec_fname("alvr_server_bootstrap")),
-        server_build_dir().join(exec_fname("ALVR")),
-    )?;
 
     // if cfg!(target_os = "linux") {
     //     use std::io::Write;

--- a/alvr/xtask/src/lib.rs
+++ b/alvr/xtask/src/lib.rs
@@ -28,11 +28,11 @@ const DRIVER_FNAME: &str = "driver_alvr_server.so";
 const DRIVER_FNAME: &str = "driver_alvr_server.dll";
 
 #[cfg(target_os = "linux")]
-fn exec_fname(name: &str) -> String {
+pub fn exec_fname(name: &str) -> String {
     name.to_owned()
 }
 #[cfg(windows)]
-fn exec_fname(name: &str) -> String {
+pub fn exec_fname(name: &str) -> String {
     format!("{}.exe", name)
 }
 
@@ -76,13 +76,13 @@ fn msbuild_path() -> PathBuf {
 }
 
 #[cfg(target_os = "linux")]
-fn steamvr_bin_dir() -> PathBuf {
+pub fn steamvr_bin_dir() -> PathBuf {
     dirs::home_dir()
         .unwrap()
         .join(".steam/steam/steamapps/common/SteamVR/bin/linux64")
 }
 #[cfg(windows)]
-fn steamvr_bin_dir() -> PathBuf {
+pub fn steamvr_bin_dir() -> PathBuf {
     PathBuf::from("C:/Program Files (x86)/Steam/steamapps/common/SteamVR/bin/win64")
 }
 


### PR DESCRIPTION
* `/session` request now require the correct use of GET or POST. POST requests now return code 199 if the settings_cache could not be correctly reconstructed using the given session.json, and settings remain unchanged. Both in case of successful or unsuccessful reconstruction, a `session_old.json` file is created containing a backup of session.json (this file is not created in case the received session.json is already valid). Invalid data for fields other than settings_cache is ignored silently.
* `settings.json` does not exist anymore. The Settings structure is derived from session.json when alvr_server_driver_ext requests it.
* driver_log.txt is now created in the TEMP folder.
* Compilation: speed up compilation times and always check for library updates
* Add `/launch_steamvr` request.