### PR TITLE
Fix missing and weak/pulsing haptics

### DIFF
--- a/alvr/client_hmd/app/src/main/cpp/ovr_context.h
+++ b/alvr/client_hmd/app/src/main/cpp/ovr_context.h
@@ -125,6 +125,7 @@ private:
         uint64_t endUs;
         float amplitude;
         float frequency;
+        bool fresh;
         bool buffered;
     };
     // mHapticsState[0]: right hand state


### PR DESCRIPTION
A couple of simple changes to fix the issues I described here: https://github.com/JackD83/ALVR/issues/21#issuecomment-660525020

Rendering thread now computes the haptics start time instead of networking so the last received haptics feedback is guaranteed to play.

I also moved the sine function that generates haptics buffer on the quest to [0,+1] from [-1,+1] so it uses the whole sine instead of just half.