### PR TITLE
Remove constantly set CheckState attributes

### DIFF
--- a/ALVR/Launcher.Designer.cs
+++ b/ALVR/Launcher.Designer.cs
@@ -1928,7 +1928,6 @@
             // 
             this.soundCheckBox.AutoSize = true;
             this.soundCheckBox.Checked = global::ALVR.Properties.Settings.Default.enableSound;
-            this.soundCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.soundCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "enableSound", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.soundCheckBox.Location = new System.Drawing.Point(6, 6);
             this.soundCheckBox.Margin = new System.Windows.Forms.Padding(6);
@@ -2016,7 +2015,6 @@
             this.defaultSoundDeviceCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.defaultSoundDeviceCheckBox.AutoSize = true;
             this.defaultSoundDeviceCheckBox.Checked = global::ALVR.Properties.Settings.Default.useDefaultSoundDevice;
-            this.defaultSoundDeviceCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.defaultSoundDeviceCheckBox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::ALVR.Properties.Settings.Default, "useDefaultSoundDevice", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.defaultSoundDeviceCheckBox.Location = new System.Drawing.Point(40, 59);
             this.defaultSoundDeviceCheckBox.Margin = new System.Windows.Forms.Padding(40, 6, 6, 6);


### PR DESCRIPTION
Fix sound device being reset to default device every time ALVR (old .NET GUI) is opened and closed without opening Sound tab.

For some reason this issue always comes back (I have removed the attribute using text editor, not by "designer tool"), but I am not sure whether we should investigate why/how these code lines come back as .NET GUI will be discontinued. 

Should we make a new release - ev11.0.1 or something like that with this bugfix?