### PR TITLE
Do not error on certain GPU's

### DIFF
--- a/server_release_template/web_gui/js/app/setupWizard.js
+++ b/server_release_template/web_gui/js/app/setupWizard.js
@@ -11,10 +11,15 @@ define([
             constructor() {
                 const gl = document.createElement('canvas').getContext('webgl');
                 const debugInfo = gl.getExtension("WEBGL_debug_renderer_info");
-                var rawGPUInfo = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
-
-                this.fullName = rawGPUInfo.match(/((NVIDIA|AMD|Intel)[^\d]*[^\s]+)/)[0];
+                const rawGPUInfo = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
+                const match = rawGPUInfo.match(/((NVIDIA|AMD|Intel)[^\d]*[^\s]+)/)
+                if(match) {
+                this.fullName = match[0];
                 [this.dev, this.name] = this.fullName.split(/(?<=^\S+)\s/);
+                } else {
+                    this.fullName = this.name = rawGPUInfo;
+                    this.dev = 'unknown'
+                }
             }
         }
 


### PR DESCRIPTION
This will handle edge cases where the GPU is not an expected value.
An example of this is if your on your phone.
Oh, I also replaced a case of `var` with `const` cause it's bad to use var unless you need it,